### PR TITLE
Copy DMSF options

### DIFF
--- a/app/models/dmsf_folder.rb
+++ b/app/models/dmsf_folder.rb
@@ -128,6 +128,25 @@ class DmsfFolder < ActiveRecord::Base
     self.subfolders.each {|subfolder| file_count += subfolder.deep_file_count}
     file_count
   end
+  
+  def deep_folder_count    
+    folder_count = self.subfolders.length
+    self.subfolders.each {|subfolder| folder_count += subfolder.deep_folder_count}
+    folder_count    
+  end
+  
+  def self.project_deep_folder_count(project)    
+    subfolders = self.project_root_folders(project) 
+    folder_count = subfolders.length 
+    subfolders.each{|subfolder| folder_count += subfolder.deep_folder_count}
+    folder_count
+  end
+  
+  def self.project_deep_file_count(project)
+    file_count = DmsfFile.project_root_files(project).length
+    self.project_root_folders(project).each{|subfolder| file_count += subfolder.deep_file_count}
+    file_count
+  end
 
   def deep_size
     size = 0

--- a/app/views/projects/copy.html.erb
+++ b/app/views/projects/copy.html.erb
@@ -1,0 +1,23 @@
+<h2><%=l(:label_project_new)%></h2>
+
+<%= labelled_form_for @project, :url => { :action => "copy" } do |f| %>
+<%= render :partial => 'form', :locals => { :f => f } %>
+
+<fieldset class="box tabular"><legend><%= l(:button_copy) %></legend>
+  <label class="block"><%= check_box_tag 'only[]', 'members', true %> <%= l(:label_member_plural) %> (<%= @source_project.members.count %>)</label>
+  <label class="block"><%= check_box_tag 'only[]', 'versions', true %> <%= l(:label_version_plural) %> (<%= @source_project.versions.count %>)</label>
+  <label class="block"><%= check_box_tag 'only[]', 'issue_categories', true %> <%= l(:label_issue_category_plural) %> (<%= @source_project.issue_categories.count %>)</label>
+  <label class="block"><%= check_box_tag 'only[]', 'issues', true %> <%= l(:label_issue_plural) %> (<%= @source_project.issues.count %>)</label>
+  <label class="block"><%= check_box_tag 'only[]', 'queries', true %> <%= l(:label_query_plural) %> (<%= @source_project.queries.count %>)</label>
+  <label class="block"><%= check_box_tag 'only[]', 'boards', true %> <%= l(:label_board_plural) %> (<%= @source_project.boards.count %>)</label>
+  <label class="block"><%= check_box_tag 'only[]', 'wiki', true %> <%= l(:label_wiki_page_plural) %> (<%= @source_project.wiki.nil? ? 0 : @source_project.wiki.pages.count %>)</label>
+  <!-- DMSF extension start -->  
+  <label class="block"><%= check_box_tag 'only[]', 'dmsf', true %> <%= l(:dmsf) %> (<%= DmsfFolder.project_deep_folder_count(@source_project) %>/<%= DmsfFolder.project_deep_file_count(@source_project) %>)</label>
+  <!-- DMSF extension end -->
+  <%= hidden_field_tag 'only[]', '' %>
+  <br />
+  <label class="block"><%= check_box_tag 'notifications', 1, params[:notifications] %> <%= l(:label_project_copy_notifications) %></label>
+</fieldset>
+
+<%= submit_tag l(:button_copy) %>
+<% end %>


### PR DESCRIPTION
I've added the copy DMSF option when copying a project. You were right that it was necessary to override project copy view and the function copy of the project model.
I'm afraid that we can't expect that Redmine developers add view hook in reasonable time. Also project copy hook model_project_copy_before_save can't be used because we would need to add third parameter with option list to know whether a user checked "Copy DMSF" or not.
It's up to you if you accept this pull request and include the changes into the master branch.
