### PR TITLE
url links backward compatibility

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,9 @@ RedmineApp::Application.routes.draw do
   get '/dmsf/files/:id/download/:download', :controller => 'dmsf_files', :action => 'show'
   get '/dmsf/files/:id', :controller => 'dmsf_files', :action => 'show'
 
+  # Just to keep backward compatibility with old external direct links
+  get '/dmsf_files/:id', :controller => 'dmsf_files', :action => 'show'
+
   #
   # files_copy controller
   #   /dmsf/files/<file id>/copy


### PR DESCRIPTION
I've added one obsolete route into config/routes.rb in order to keep compatibility with old external direct url links. Otherwise existing links don't work. 

E.g.: "Document":/dmsf_files996?download=
