### PR TITLE
'zip' gem conflicts with 'rubyzip' on Redmine XLS Export Plugin.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem "zip"
+gem "rubyzip"
 gem "simple_enum"
 gem "nokogiri", ">= 1.4.2"
 gem "uuidtools", "~> 2.1.1"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ As of version 1.4.4 of this plugin:
   * Bundler 1.1 or greater (Gem)
   * Redmine 2.0.x 
   * Rails 3.2.x (Inline with Redmine installation requirement) 
-  * zip (Gem)
+  * rubyzip (Gem)
   * Nokogiri 1.4.2 or greater (Gem)
   * UUIDTools 2.1.1 or greater (less than 2.2.0) (Gem)
   * simple_enum (Gem)


### PR DESCRIPTION
### What steps will reproduce the problem?
1. Install DMSF Plugin and XLS Export Plugin.
   http://www.redmine.org/plugins/redmine_xls_export
2. Do following because XLS Export Plugin needs Zip::ZipOutputStream::write_buffer.
   <pre>
   $ irb
   >> require 'zip/zip'
   => true
   >> p defined?(Zip::ZipOutputStream::write_buffer))
   => nil
   </pre>
### What is the expected output? What do you see instead?

Now following issue is occurred. I wanna fix it.
https://github.com/two-pack/redmine_xls_export/issues/19
### What version of the product are you using? On what operating system?
#### Environment:

  Redmine version                          2.2.4.stable
  Ruby version                             1.8.7 (universal-darwin11.0)
  Rails version                            3.2.13
  Environment                              development
  Database adapter                         MySQL
#### Redmine plugins:

  redmine_dmsf                             1.4.5 stable
  redmine_plugin_views_revisions           0.0.1
  redmine_xls_export                       0.2.1
### Please provide any additional information below.

When loading init.rb in XLS Export, $: has paths of 'zip' and 'rubyzip'.
Index of 'zip' in $: is earlier then 'rubyzip'. And DSMF and XLS Export are same condition.
So 'zip' is loaded first, and same name library ISN'T loaded with require.

By the way, I checked DMSF with 'rubyzip', of course not all the things, maybe no problem.
I pull-request and want to change 'zip' to 'rubyzip' on your plugin if you can.
