### PR TITLE
Show document on search link

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -61,7 +61,7 @@ class DmsfFile < ActiveRecord::Base
   
   acts_as_event :title => Proc.new {|o| "#{o.title} - #{o.name}"},
                 :description => Proc.new {|o| o.description },
-                :url => Proc.new {|o| {:controller => 'dmsf_files', :action => 'show', :id => o, :download => ''}},
+                :url => Proc.new {|o| {:controller => 'dmsf_files', :action => 'show', :id => o}},
                 :datetime => Proc.new {|o| o.updated_at },
                 :author => Proc.new {|o| o.last_revision.user }
   


### PR DESCRIPTION
Thanks for that. This is another change I make every time I have installed the plugin. It changes the search link to a link that shows the file instead of just downloading the file. I am not sure if this has any negative impacts anywhere else, I have not found any (yet!) and not sure if this was done intentionally.

Cheers,
Will
