### PR TITLE
Change xapian-full gem to avoid install issues on Linux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ end
 
 #Allows --without=xapian
 group :xapian do
-  gem 'xapian-full', :require => false
+  gem 'xapian-full-alaveteli', :require => false
 end


### PR DESCRIPTION
xapian-full has a problem to install on Linux: https://github.com/rlane/xapian-full/pull/4
No new release has been published mainstream to fix the bug: https://github.com/rlane/xapian-full/issues/5

Somebody has published a gem to fix that: https://rubygems.org/gems/xapian-full-alaveteli

I propose this PR to avoid new issues like this: https://github.com/danmunn/redmine_dmsf/issues/62
