### PR TITLE
Fixed the trashbin migration's UPDATE raw query (Postgres error)

### DIFF
--- a/db/migrate/20140519133201_trash_bin.rb
+++ b/db/migrate/20140519133201_trash_bin.rb
@@ -22,7 +22,7 @@ class TrashBin < ActiveRecord::Migration
     add_column :dmsf_folders, :deleted, :boolean, :default => false, :null => false
     add_column :dmsf_folders, :deleted_by_user_id, :integer
     
-    DmsfFolder.connection.execute('UPDATE dmsf_folders SET deleted = 0')
+    DmsfFolder.connection.execute('UPDATE dmsf_folders SET deleted = false')
   end
   
   def down


### PR DESCRIPTION
Fixed the query so it actually uses a boolean and not an integer (causes a PG::DatatypeMismatch on Postgres)
