### PR TITLE
added view url for dmsf files

### DIFF
--- a/app/controllers/dmsf_files_controller.rb
+++ b/app/controllers/dmsf_files_controller.rb
@@ -29,6 +29,19 @@ class DmsfFilesController < ApplicationController
   helper :all
   helper :dmsf_workflows
 
+  def view
+    @revision = @file.last_revision
+
+    check_project(@revision.file)
+    access = DmsfFileRevisionAccess.new(:user_id => User.current.id, :dmsf_file_revision_id => @revision.id,
+      :action => DmsfFileRevisionAccess::DownloadAction)
+    access.save!
+    send_file(@revision.disk_file,
+      :filename => filename_for_content_disposition(@revision.name),
+      :type => @revision.detect_content_type,
+      :disposition => 'inline')
+  end
+
   def show
     # The download is put here to provide more clear and usable links
     if params.has_key?(:download)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ RedmineApp::Application.routes.draw do
   get '/dmsf/files/:id/revision/delete', :controller => 'dmsf_files', :action => 'delete_revision', :as => 'delete_revision'
   get '/dmsf/files/:id/download', :controller => 'dmsf_files', :action => 'show', :download => '' # Otherwise will not route nil download param
   get '/dmsf/files/:id/download/:download', :controller => 'dmsf_files', :action => 'show', :as => 'download_revision'
+  get '/dmsf/files/:id/view', :controller => 'dmsf_files', :action => 'view'
   get '/dmsf/files/:id', :controller => 'dmsf_files', :action => 'show', :as => 'dmsf_file'  
   delete '/dmsf/files/:id', :controller => 'dmsf_files', :action => 'delete'
   get '/dmsf/files/:id/restore', :controller => 'dmsf_files', :action => 'restore', :as => 'restore_dmsf_file'

--- a/init.rb
+++ b/init.rb
@@ -59,7 +59,7 @@ Redmine::Plugin.register :redmine_dmsf do
       {:dmsf_state => [:user_pref_save]}
     permission :view_dmsf_files, 
       {:dmsf => [:entries_operation, :entries_email, :download_email_entries, :tag_changed], 
-        :dmsf_files => [:show], 
+        :dmsf_files => [:show, :view],
         :dmsf_files_copy => [:new, :create, :move], 
         :dmsf_workflows => [:log]}, 
       :read => true


### PR DESCRIPTION
the url http://<appl_addr>/dmsf/files/<file_id>/view allows the user to get a file as http request with content-disposition set to inline
which enables the browser to view files of which it can display the mime-types without downloading them (e.g. insert a image from dmsf into wiki entry)

Conflicts:
    config/routes.rb
