### PR TITLE
Update _file.html.erb

### DIFF
--- a/app/views/dmsf/_file.html.erb
+++ b/app/views/dmsf/_file.html.erb
@@ -25,7 +25,7 @@
 <td class="check"><%= check_box_tag(name, id, false, 
   :title => l(:title_check_for_zip_download_or_email)) %></td>
 <td class="title">
-  <% file_download_url = url_for({:only_path => false, :controller => :dmsf_files, :action => 'show', :id => file, :download => ''}) %>
+  <% file_download_url = url_for({:only_path => true, :controller => :dmsf_files, :action => 'show', :id => file, :download => ''}) %>
   <%= link_to(h(title),
     file_download_url,
     :class => "icon icon-file #{DmsfHelper.filetype_css(file.name)}",


### PR DESCRIPTION
We have setup a redmine for internal use. At the same time, a proxy is setup too so that external users can enjoy our bug tracking service. If the url is created as a full path, external user can't download the file as it is returning the file of internal server address. Having the relative path generated can make both internal and external parties possible to download the file.
