### PR TITLE
Enforce dav4rack verion in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rubyzip', '>= 1.0.0'
 gem 'zip-zip' # Just to avoid 'cannot load such file -- zip/zip' error
 gem 'simple_enum'
 gem 'uuidtools', '~> 2.1.1'
-gem 'dav4rack'
+gem 'dav4rack',  '~> 0.3.0'
 
 group :production do
   gem 'nokogiri', '>= 1.5.10'


### PR DESCRIPTION
Existing DMSF installations using older versions of dav4rack will
not install the appropriate version when bundle install is called.

Require version 0.3.0 of the gem as it contains the Utils name
space, not present in 0.2.11.
