### PR TITLE
Option in the activity log to show downloads

### DIFF
--- a/app/models/dmsf_file_revision_access.rb
+++ b/app/models/dmsf_file_revision_access.rb
@@ -24,4 +24,21 @@ class DmsfFileRevisionAccess < ActiveRecord::Base
   DownloadAction = 0
   EmailAction = 1
 
+  acts_as_event :title => Proc.new {|o| "#{l(:label_dmsf_downloaded)}: #{o.file.dmsf_path_str}"},
+    :url => Proc.new {|o| {:controller => 'dmsf_files', :action => 'show', :id => o.file}},
+    :datetime => Proc.new {|o| o.updated_at },
+    :description => Proc.new {|o| o.revision.comment },
+    :author => Proc.new {|o| o.user }    
+   acts_as_activity_provider :type => 'dmsf_folders',
+    :timestamp => "#{DmsfFileRevisionAccess.table_name}.updated_at",
+    :author_key => "#{DmsfFileRevisionAccess.table_name}.user_id",
+    :permission => :view_dmsf_files,
+    :find_options => {:select => "#{DmsfFileRevisionAccess.table_name}.*", 
+      :joins => 
+        "INNER JOIN #{DmsfFileRevision.table_name} ON #{DmsfFileRevisionAccess.table_name}.dmsf_file_revision_id = #{DmsfFileRevision.table_name}.id " +
+        "INNER JOIN #{DmsfFile.table_name} ON #{DmsfFileRevision.table_name}.dmsf_file_id = #{DmsfFile.table_name}.id " +
+        "INNER JOIN #{Project.table_name} ON #{DmsfFile.table_name}.project_id = #{Project.table_name}.id",
+      :conditions => ["#{DmsfFile.table_name}.deleted = :false", {:false => false}]
+     }
+
 end

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -21,6 +21,8 @@
 cs:
   dmsf: DMSF
   label_dmsf_file_plural: Dmsf soubory
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Není nic vybráno
   error_email_to_must_be_entered: Musí být zadán adresát  
   warning_file_already_locked: Soubor už je zamčen
@@ -172,6 +174,7 @@ cs:
   heading_access_first: První
   heading_access_last: Poslední
   label_dmsf_updated: DMSF změněno
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Celková velikost všech souborů v adresáři
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: Neexistuje projekt, do kterého můžete kopírovat

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@
 en:
   dmsf: DMSF
   label_dmsf_file_plural: Dmsf files
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: No entries selected
   error_email_to_must_be_entered: Email To must be entered  
   warning_file_already_locked: File already locked
@@ -171,7 +173,8 @@ en:
   heading_access_downloads_emails: Downloads/Emails
   heading_access_first: First
   heading_access_last: Last
-  label_dmsf_updated: DMSF updated
+  label_dmsf_updated: DMSF document updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Total size of all files under this folder
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,6 +21,8 @@
 es:
   dmsf: DMSF
   label_dmsf_file_plural: DMSF Archivos
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: No ha seleccionado ningún ítem
   error_email_to_must_be_entered: Ingrese un email  
   warning_file_already_locked: El archivo ya está bloqueado
@@ -172,6 +174,7 @@ es:
   heading_access_first: First
   heading_access_last: Last
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Total size of all files under this folder
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -21,6 +21,8 @@
 fr:
   dmsf: DMSF
   label_dmsf_file_plural: Fichiers DMSF
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Aucun fichier sélectionné
   error_email_to_must_be_entered: "La saisie d'une adresse mail est obligatoire"
   warning_file_already_locked: Fichier déjà verrouillé
@@ -172,6 +174,7 @@ fr:
   heading_access_first: Premier
   heading_access_last: Dernier
   label_dmsf_updated: Dépôt ou mise à jour du document
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Taille totale des fichiers de ce dossier
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: "Le projet de destination n'est pas défini"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,8 @@
 ja:
   dmsf: DMSF
   label_dmsf_file_plural: Dmsf ファイル
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: エントリーが選ばれていません
   error_email_to_must_be_entered: 電子メールの To 先は省略できません  
   warning_file_already_locked: ファイルは既にロックされています
@@ -172,6 +174,7 @@ ja:
   heading_access_first: 初回アクセス
   heading_access_last: 最終アクセス
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: このフォルダにある全ファイルの合計サイズ
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: ファイルをコピーするプロジェクトがありません

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -22,6 +22,8 @@
 pl:
   dmsf: DMSF
   label_dmsf_file_plural: Pliki Dmsf
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Nie zaznaczono żadnych wierszy
   error_email_to_must_be_entered: Musisz podać adres email  
   warning_file_already_locked: Plik jest już zablokowany
@@ -173,6 +175,7 @@ pl:
   heading_access_first: Pierwszy
   heading_access_last: Ostatni
   label_dmsf_updated: DMSF został zaktualizowany
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Łączny rozmiar plików w folderze
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: Brak projektu do skopiowania pliku

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -21,6 +21,8 @@
 ru:
   dmsf: DMSF
   label_dmsf_file_plural: Файлы DMSF
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Файлы не выбраны
   error_email_to_must_be_entered: Нужно указать, на какую почту отправить письмо  
   warning_file_already_locked: Файл уже заблокирован
@@ -172,6 +174,7 @@ ru:
   heading_access_first: Первый
   heading_access_last: Последний
   label_dmsf_updated: Документ обновлен
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Общий размер всех файлов в этой папке
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: Не выбран проект, в который нужно скопировать файл

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -21,6 +21,8 @@
 sl:
   dmsf: Arhiv
   label_dmsf_file_plural: Arhivske datoteke
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Ničesar niste izbrali
   error_email_to_must_be_entered: Email Naslovnik mora bit izbran  
   warning_file_already_locked: Datoteka že zaklenjena
@@ -172,6 +174,7 @@ sl:
   heading_access_first: Prvi
   heading_access_last: Zadnji
   label_dmsf_updated: Arhiv posodobljen
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Skupna velikost vseh datotek v tej mapi
   project_module_dmsf: Arhiv  
   warning_no_project_to_copy_file_to: Ni projekta kamor bi kopiral datoteko

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -22,6 +22,8 @@
 "zh-TW":
   dmsf: 文件總管
   label_dmsf_file_plural: 文件檔案
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: 尚未選取任何項目
   error_email_to_must_be_entered: 請輸入收件者的電子郵件
   warning_file_already_locked: 檔案己經鎖定
@@ -174,6 +176,7 @@
   heading_access_first: First
   heading_access_last: Last
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: 資料夾所有檔案的檔案大小
   project_module_dmsf: 文件總管
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -21,6 +21,8 @@
 zh:
   dmsf: 文档管家
   label_dmsf_file_plural: Dmsf files
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: 未选择任何条目
   error_email_to_must_be_entered: 请输入电子邮件  
   warning_file_already_locked: 文件已经锁定
@@ -172,6 +174,7 @@ zh:
   heading_access_first: 首次
   heading_access_last: 末次
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: 文件夹所有文件总大小
   project_module_dmsf: 文档管家  
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/init.rb
+++ b/init.rb
@@ -49,6 +49,7 @@ Redmine::Plugin.register :redmine_dmsf do
   menu :project_menu, :dmsf, { :controller => 'dmsf', :action => 'show' }, :caption => :menu_dmsf, :before => :documents, :param => :id
   
   activity_provider :dmsf_files, :class_name => 'DmsfFileRevision', :default => true
+  activity_provider :dmsf_folders, :class_name => 'DmsfFileRevisionAccess', :default => false
   
   project_module :dmsf do
     permission :view_dmsf_folders, 


### PR DESCRIPTION
Hi Karel,

Hope you are well. I am trying to add an option to be able to see document downloads in the activity stream, but I am having issues (Rails is not my first language). Ideally the init.rb file should look like:

```
activity_provider :dmsf_file_revisions, :class_name => 'DmsfFileRevision', :default => true
activity_provider : dmsf_file_revision_accesses, :class_name => 'DmsfFileRevisionAccess', :default => false
```

I have used :dmsf_folders for the event type because I cannot get :dmsf_file_revision_accesses to work. I noticed that you used :dmsf_files as event type, is this because you could not get : dmsf_file_revisions to work?

Sorry to bother you and any help you could provide would be greatly appreciated.

Regards,
Will
