### PR TITLE
Added option to view downloads on Activity stream

### DIFF
--- a/app/controllers/dmsf_controller.rb
+++ b/app/controllers/dmsf_controller.rb
@@ -311,7 +311,7 @@ class DmsfController < ApplicationController
       if @folder
         @folder.notify_deactivate
       else
-        @project.dmsf_notification = false
+        @project.dmsf_notification = nil
         @project.save
       end
       flash[:notice] = l(:notice_folder_notifications_deactivated)

--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -66,7 +66,17 @@ class DmsfFile < ActiveRecord::Base
                 :url => Proc.new {|o| {:controller => 'dmsf_files', :action => 'show', :id => o}},
                 :datetime => Proc.new {|o| o.updated_at },
                 :author => Proc.new {|o| o.last_revision.user }
-    
+
+  before_create :default_values
+  def default_values
+    @notifications = Setting.plugin_redmine_dmsf['dmsf_default_notifications']
+    if @notifications == '1'
+      self.notification = true
+    else
+      self.notification = nil
+    end
+  end
+
   @@storage_path = nil
 
   def self.storage_path
@@ -176,7 +186,7 @@ class DmsfFile < ActiveRecord::Base
   end
   
   def notify_deactivate
-    self.notification = false
+    self.notification = nil
     self.save!
   end
   

--- a/app/models/dmsf_file_revision.rb
+++ b/app/models/dmsf_file_revision.rb
@@ -37,10 +37,10 @@ class DmsfFileRevision < ActiveRecord::Base
     :datetime => Proc.new {|o| o.updated_at },
     :description => Proc.new {|o| o.comment },
     :author => Proc.new {|o| o.user }          
-  acts_as_activity_provider :type => 'dmsf_files',
+  acts_as_activity_provider :type => 'dmsf_file_revisions',
     :timestamp => "#{DmsfFileRevision.table_name}.updated_at",
     :author_key => "#{DmsfFileRevision.table_name}.user_id",
-    :permission => :view_dmsf_files,
+    :permission => :view_dmsf_file_revisions,
     :find_options => {:select => "#{DmsfFileRevision.table_name}.*", 
       :joins => 
         "INNER JOIN #{DmsfFile.table_name} ON #{DmsfFileRevision.table_name}.dmsf_file_id = #{DmsfFile.table_name}.id " +

--- a/app/models/dmsf_file_revision_access.rb
+++ b/app/models/dmsf_file_revision_access.rb
@@ -20,8 +20,27 @@ class DmsfFileRevisionAccess < ActiveRecord::Base
   unloadable
   belongs_to :revision, :class_name => 'DmsfFileRevision', :foreign_key => 'dmsf_file_revision_id'
   belongs_to :user
+  delegate :project, :to => :revision, :allow_nil => false
+  delegate :file, :to => :revision, :allow_nil => false
 
   DownloadAction = 0
   EmailAction = 1
+
+  acts_as_event :title => Proc.new {|o| "#{l(:label_dmsf_downloaded)}: #{o.file.dmsf_path_str}"},
+    :url => Proc.new {|o| {:controller => 'dmsf_files', :action => 'show', :id => o.file}},
+    :datetime => Proc.new {|o| o.updated_at },
+    :description => Proc.new {|o| o.revision.comment },
+    :author => Proc.new {|o| o.user }    
+   acts_as_activity_provider :type => 'dmsf_file_revision_accesses',
+    :timestamp => "#{DmsfFileRevisionAccess.table_name}.updated_at",
+    :author_key => "#{DmsfFileRevisionAccess.table_name}.user_id",
+    :permission => :view_dmsf_file_revision_accesses,
+    :find_options => {:select => "#{DmsfFileRevisionAccess.table_name}.*", 
+      :joins => 
+        "INNER JOIN #{DmsfFileRevision.table_name} ON #{DmsfFileRevisionAccess.table_name}.dmsf_file_revision_id = #{DmsfFileRevision.table_name}.id " +
+        "INNER JOIN #{DmsfFile.table_name} ON #{DmsfFileRevision.table_name}.dmsf_file_id = #{DmsfFile.table_name}.id " +
+        "INNER JOIN #{Project.table_name} ON #{DmsfFile.table_name}.project_id = #{Project.table_name}.id",
+      :conditions => ["#{DmsfFile.table_name}.deleted = :false", {:false => false}]
+     }
 
 end

--- a/app/models/dmsf_folder.rb
+++ b/app/models/dmsf_folder.rb
@@ -63,7 +63,17 @@ class DmsfFolder < ActiveRecord::Base
                 :url => Proc.new {|o| {:controller => 'dmsf', :action => 'show', :id => o.project, :folder_id => o}},
                 :datetime => Proc.new {|o| o.updated_at },
                 :author => Proc.new {|o| o.user }
-  
+
+  before_create :default_values
+  def default_values
+    @notifications = Setting.plugin_redmine_dmsf['dmsf_default_notifications']
+    if @notifications == '1'
+      self.notification = true
+    else
+      self.notification = nil
+    end
+  end
+
   def check_cycle
     folders = []
     self.subfolders.each {|f| folders.push(f)}
@@ -138,7 +148,7 @@ class DmsfFolder < ActiveRecord::Base
   end
   
   def notify_deactivate
-    self.notification = false
+    self.notification = nil
     self.save!
   end
   

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -21,6 +21,8 @@
 cs:
   dmsf: DMSF
   label_dmsf_file_plural: Dmsf soubory
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Není nic vybráno
   error_email_to_must_be_entered: Musí být zadán adresát  
   warning_file_already_locked: Soubor už je zamčen
@@ -138,6 +140,8 @@ cs:
   heading_uploaded_files: Nahrané soubory
   submit_commit: Potvrdit
   link_documents: Dokumenty
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: Procházet dokumenty
   permission_user_preferences: Nastavení uživatele
   permission_view_dmsf_files: Zobrazit dokumenty
@@ -172,6 +176,7 @@ cs:
   heading_access_first: První
   heading_access_last: Poslední
   label_dmsf_updated: DMSF změněno
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Celková velikost všech souborů v adresáři
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: Neexistuje projekt, do kterého můžete kopírovat

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -138,6 +138,8 @@ de:
   heading_uploaded_files: Hochgeladene Dateien
   submit_commit: OK
   link_documents: Dateien
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: Durchforste Dateien
   permission_user_preferences: Benutzereinstellungen
   permission_view_dmsf_files: Betrachte Dateien

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@
 en:
   dmsf: DMSF
   label_dmsf_file_plural: Dmsf files
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: No entries selected
   error_email_to_must_be_entered: Email To must be entered  
   warning_file_already_locked: File already locked
@@ -171,7 +173,8 @@ en:
   heading_access_downloads_emails: Downloads/Emails
   heading_access_first: First
   heading_access_last: Last
-  label_dmsf_updated: DMSF updated
+  label_dmsf_updated: DMSF document updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Total size of all files under this folder
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -21,6 +21,8 @@
 es:
   dmsf: DMSF
   label_dmsf_file_plural: DMSF Archivos
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: No ha seleccionado ningún ítem
   error_email_to_must_be_entered: Ingrese un email  
   warning_file_already_locked: El archivo ya está bloqueado
@@ -138,6 +140,8 @@ es:
   heading_uploaded_files: Uploaded Files
   submit_commit: Commit
   link_documents: Documents
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: Browse documents
   permission_user_preferences: User preferences
   permission_view_dmsf_files: View documents
@@ -172,6 +176,7 @@ es:
   heading_access_first: First
   heading_access_last: Last
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Total size of all files under this folder
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -21,6 +21,8 @@
 fr:
   dmsf: DMSF
   label_dmsf_file_plural: Fichiers DMSF
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Aucun fichier sélectionné
   error_email_to_must_be_entered: "La saisie d'une adresse mail est obligatoire"
   warning_file_already_locked: Fichier déjà verrouillé
@@ -138,6 +140,8 @@ fr:
   heading_uploaded_files: Document(s) transmis
   submit_commit: Appliquer
   link_documents: Documents
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: Parcourir les documents
   permission_user_preferences: Préférences utilisateur
   permission_view_dmsf_files: Afficher documents
@@ -172,6 +176,7 @@ fr:
   heading_access_first: Premier
   heading_access_last: Dernier
   label_dmsf_updated: Dépôt ou mise à jour du document
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Taille totale des fichiers de ce dossier
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: "Le projet de destination n'est pas défini"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,8 @@
 ja:
   dmsf: DMSF
   label_dmsf_file_plural: Dmsf ファイル
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: エントリーが選ばれていません
   error_email_to_must_be_entered: 電子メールの To 先は省略できません  
   warning_file_already_locked: ファイルは既にロックされています
@@ -138,6 +140,8 @@ ja:
   heading_uploaded_files: アップロードされたファイル
   submit_commit: コミット
   link_documents: 文書
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: 文書の一覧
   permission_user_preferences: ユーザ設定
   permission_view_dmsf_files: 文書の表示
@@ -172,6 +176,7 @@ ja:
   heading_access_first: 初回アクセス
   heading_access_last: 最終アクセス
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: このフォルダにある全ファイルの合計サイズ
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: ファイルをコピーするプロジェクトがありません

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -22,6 +22,8 @@
 pl:
   dmsf: DMSF
   label_dmsf_file_plural: Pliki Dmsf
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Nie zaznaczono żadnych wierszy
   error_email_to_must_be_entered: Musisz podać adres email  
   warning_file_already_locked: Plik jest już zablokowany
@@ -139,6 +141,8 @@ pl:
   heading_uploaded_files: Przesłane pliki
   submit_commit: Zatwierdź
   link_documents: Dokumenty
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: Przeglądaj dokumenty
   permission_user_preferences: Preferencje użytkownika
   permission_view_dmsf_files: Podgląd dokumentów
@@ -173,6 +177,7 @@ pl:
   heading_access_first: Pierwszy
   heading_access_last: Ostatni
   label_dmsf_updated: DMSF został zaktualizowany
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Łączny rozmiar plików w folderze
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: Brak projektu do skopiowania pliku

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -21,6 +21,8 @@
 ru:
   dmsf: DMSF
   label_dmsf_file_plural: Файлы DMSF
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Файлы не выбраны
   error_email_to_must_be_entered: Нужно указать, на какую почту отправить письмо  
   warning_file_already_locked: Файл уже заблокирован
@@ -138,6 +140,8 @@ ru:
   heading_uploaded_files: Загруженные файлы
   submit_commit: Зафиксировать
   link_documents: Документы
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: Просматривать папки
   permission_user_preferences: Настройки пользователя
   permission_view_dmsf_files: Просматривать документы
@@ -172,6 +176,7 @@ ru:
   heading_access_first: Первый
   heading_access_last: Последний
   label_dmsf_updated: Документ обновлен
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Общий размер всех файлов в этой папке
   project_module_dmsf: DMSF
   warning_no_project_to_copy_file_to: Не выбран проект, в который нужно скопировать файл

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -21,6 +21,8 @@
 sl:
   dmsf: Arhiv
   label_dmsf_file_plural: Arhivske datoteke
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: Ničesar niste izbrali
   error_email_to_must_be_entered: Email Naslovnik mora bit izbran  
   warning_file_already_locked: Datoteka že zaklenjena
@@ -138,6 +140,8 @@ sl:
   heading_uploaded_files: Naložene datoteke
   submit_commit: Shrani
   link_documents: Dokumentacija
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: Brskanje po dokumentih
   permission_user_preferences: Uporabniške nastavitve
   permission_view_dmsf_files: Preglej dokumente
@@ -172,6 +176,7 @@ sl:
   heading_access_first: Prvi
   heading_access_last: Zadnji
   label_dmsf_updated: Arhiv posodobljen
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: Skupna velikost vseh datotek v tej mapi
   project_module_dmsf: Arhiv  
   warning_no_project_to_copy_file_to: Ni projekta kamor bi kopiral datoteko

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -22,6 +22,8 @@
 "zh-TW":
   dmsf: 文件總管
   label_dmsf_file_plural: 文件檔案
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: 尚未選取任何項目
   error_email_to_must_be_entered: 請輸入收件者的電子郵件
   warning_file_already_locked: 檔案己經鎖定
@@ -141,6 +143,8 @@
   heading_uploaded_files: 上傳檔案
   submit_commit: 提交
   link_documents: 文件檔案
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: 瀏覽文件檔案
   permission_user_preferences: 使用者偏好設定
   permission_view_dmsf_files: 查看文件檔案
@@ -174,6 +178,7 @@
   heading_access_first: First
   heading_access_last: Last
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: 資料夾所有檔案的檔案大小
   project_module_dmsf: 文件總管
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -21,6 +21,8 @@
 zh:
   dmsf: 文档管家
   label_dmsf_file_plural: Dmsf files
+  label_dmsf_file_revision_plural: Dmsf document revisions
+  label_dmsf_file_revision_access_plural: Dmsf document accesses
   warning_no_entries_selected: 未选择任何条目
   error_email_to_must_be_entered: 请输入电子邮件  
   warning_file_already_locked: 文件已经锁定
@@ -138,6 +140,8 @@ zh:
   heading_uploaded_files: 上传文件
   submit_commit: 提交
   link_documents: 文档
+  permission_view_dmsf_file_revision_accesses: View downloads in Activity stream
+  permission_view_dmsf_file_revisions: View revisions in Activity stream
   permission_view_dmsf_folders: 浏览文档
   permission_user_preferences: 用户偏好设定
   permission_view_dmsf_files: 查看文档
@@ -172,6 +176,7 @@ zh:
   heading_access_first: 首次
   heading_access_last: 末次
   label_dmsf_updated: DMSF updated
+  label_dmsf_downloaded: DMSF document downloaded
   title_total_size_of_all_files: 文件夹所有文件总大小
   project_module_dmsf: 文档管家  
   warning_no_project_to_copy_file_to: No project to copy file to

--- a/db/migrate/20150120152101_notifications_nullable.rb
+++ b/db/migrate/20150120152101_notifications_nullable.rb
@@ -1,0 +1,32 @@
+# Redmine plugin for Document Management System "Features"
+#
+# Copyright (C) 2014 Karel Pičman <karel.picman@lbcfree.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+class NotificationsNullable < ActiveRecord::Migration
+  def up  
+    # Switch on the default notifications for new projects and folders
+    change_column :projects, :dmsf_notification, :boolean, :default => false, :null => true
+    change_column :dmsf_folders, :notification, :boolean, :default => false, :null => true
+    change_column :dmsf_files, :notification, :boolean, :default => false, :null => true
+  end
+  
+  def down
+    change_column :projects, :dmsf_notification, :boolean, :default => true, :null => false
+    change_column :dmsf_folders, :notification, :boolean, :default => true, :null => false
+    change_column :dmsf_files, :notification, :boolean, :default => true, :null => false
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -47,10 +47,15 @@ Redmine::Plugin.register :redmine_dmsf do
     }
   
   menu :project_menu, :dmsf, { :controller => 'dmsf', :action => 'show' }, :caption => :menu_dmsf, :before => :documents, :param => :id
-  
-  activity_provider :dmsf_files, :class_name => 'DmsfFileRevision', :default => true
+    
+  Redmine::Activity.register :dmsf_file_revision_accesses, :default => false
+  Redmine::Activity.register :dmsf_file_revisions
   
   project_module :dmsf do
+    permission :view_dmsf_file_revision_accesses, 
+      :read => true
+    permission :view_dmsf_file_revisions, 
+      :read => true
     permission :view_dmsf_folders, 
       {:dmsf => [:show], 
         :dmsf_folders_copy => [:new, :copy_to, :move_to]}, 


### PR DESCRIPTION
Hi Karel,

So figured out what the issue was. If you use a an event :dmsf_file_revision_accesses then there needs to be a permission called :view_dmsf_file_revision_accesses. This looks like a bug (that I will report to Redmine) because the permission is declared as part of the acts_as_activity_provider method.

Anywho, this is a small update that updates the activity stream so that users can see downloads as well.

Regards,
Will
 