### PR TITLE
Fixed download links on main page

### DIFF
--- a/app/views/dmsf/_file.html.erb
+++ b/app/views/dmsf/_file.html.erb
@@ -27,7 +27,7 @@
 <td class="check"><%= check_box_tag(name, id, false, 
   :title => l(:title_check_for_zip_download_or_email)) %></td>
 <td class="title">
-  <% file_view_url = url_for({:only_path => false, :controller => :dmsf_files, :action => 'view', :id => file}) %>
+  <% file_view_url = url_for({:controller => :dmsf_files, :action => 'view', :id => file}) %>
   <%= link_to(h(title),
     file_view_url,
     :target => "_blank",


### PR DESCRIPTION
On the main page, the download urls were absolute urls created with just the hostname of the machine.
They didn't include the fully qualified domain name, nor were using the one from the Redmine settings.

I removed the ':only_path => false' parameter from url_for(), so it's using relative urls now.
