### PR TITLE
Bug fix for missing delete icon for url item

### DIFF
--- a/app/views/dmsf/_url.html.erb
+++ b/app/views/dmsf/_url.html.erb
@@ -39,7 +39,7 @@
       <span class="icon"></span>
       <span class="icon"></span>
       <span class="icon"></span>
-      <%= link_to('delete.png',            
+      <%= link_to(image_tag('delete.png'),            
         dmsf_link_path(link),
         :data => {:confirm => l(:text_are_you_sure)},
         :method => :delete,


### PR DESCRIPTION
before fix, it shows "delete.png" text for External Url item
After fix, it shows the picture of "delete.png"