### PR TITLE
Remove invalid opening paranthesis in DmsfFile search

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -292,7 +292,7 @@ class DmsfFile < ActiveRecord::Base
     project_ids = projects.collect(&:id) if projects           
     
     if options[:offset]      
-       limit_options = ["(dmsf_files.updated_at #{options[:before] ? '<' : '>'} ?", options[:offset]]
+       limit_options = ["dmsf_files.updated_at #{options[:before] ? '<' : '>'} ?", options[:offset]]
     end
     
     if options[:titles_only]


### PR DESCRIPTION
When providing the `offset` option to a search (which is e.g. done when clicking on the next page of search results), the `DmsfFile.search` method produces invalid SQL with a superfluous opening parenthesis.

This patch simply removes it.