### PR TITLE
Add xz to the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,16 +77,26 @@ From Omega documentation:
 
 On Debian use:
 
-```apt-get install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf xpdf-utils antiword unzip\
- catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf catdvi djview djview3 uuid uuid-dev```
+```
+apt-get install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf \
+  xpdf-utils antiword unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf \
+  catdvi djview djview3 uuid uuid-dev
+```
 
 On Ubuntu use:
 
-```sudo apt-get install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf antiword\
-unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf catdvi djview djview3 uuid uuid-dev```
+```
+sudo apt-get install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf \
+  antiword unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf catdvi djview \
+  djview3 uuid uuid-dev
+```
 
 On CentOS user:
-```sudo yum install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf antiword\ unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf catdvi djview djview3 uuid uuid-dev```
+```
+sudo yum install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf \
+  antiword unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf catdvi djview \
+  djview3 uuid uuid-dev
+```
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ On Debian use:
 ```
 apt-get install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf \
   xpdf-utils antiword unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf \
-  catdvi djview djview3 uuid uuid-dev
+  catdvi djview djview3 uuid uuid-dev xz-utils
 ```
 
 On Ubuntu use:
@@ -88,14 +88,14 @@ On Ubuntu use:
 ```
 sudo apt-get install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf \
   antiword unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf catdvi djview \
-  djview3 uuid uuid-dev
+  djview3 uuid uuid-dev xz-utils
 ```
 
 On CentOS user:
 ```
 sudo yum install libxapian-ruby1.9.1 xapian-omega libxapian-dev xpdf \
   antiword unzip catdoc libwpd-0.9-9 libwps-0.2-2 gzip unrtf catdvi djview \
-  djview3 uuid uuid-dev
+  djview3 uuid uuid-dev xz
 ```
 
 Usage


### PR DESCRIPTION
On my minimal Ubuntu installation, the xapian-full-alaveteli gem could not be installed, because the xz command was not available. These commits do some cosmetics in the dependencies code blocks and mention the xz package for the various distributions.