### PR TITLE
Global Title Format

### DIFF
--- a/app/views/settings/_dmsf_settings.html.erb
+++ b/app/views/settings/_dmsf_settings.html.erb
@@ -112,6 +112,14 @@
   </em>
 </p>
 
+<p>
+  <%= content_tag(:label, l(:label_title_format)) %>  
+  <%= text_field_tag 'settings[dmsf_global_title_format]', @settings['dmsf_global_title_format'], :size => 10 %>
+  <em class="info">
+    <%= l(:text_title_format) %> <%= l(:label_default) %>: %t_%v
+  </em>
+</p>
+
 <hr/>
 
 <p>

--- a/init.rb
+++ b/init.rb
@@ -45,7 +45,8 @@ Redmine::Plugin.register :redmine_dmsf do
       'dmsf_stemming_lang' => 'english',
       'dmsf_stemming_strategy' => 'STEM_NONE',
       'dmsf_webdav' => '1',
-      'dmsf_display_notified_recipients' => 0
+      'dmsf_display_notified_recipients' => 0,
+      'dmsf_global_title_format' => '%t_%v'
     }
   
   menu :project_menu, :dmsf, { :controller => 'dmsf', :action => 'show' }, :caption => :menu_dmsf, :before => :documents, :param => :id

--- a/lib/dmsf_zip.rb
+++ b/lib/dmsf_zip.rb
@@ -47,7 +47,12 @@ class DmsfZip
     unless @files.include?(file)
       string_path = file.dmsf_folder.nil? ? '' : "#{file.dmsf_folder.dmsf_path_str}/"
       string_path = string_path[(root_path.length + 1) .. string_path.length] if root_path
-      string_path += file.formatted_name(member ? member.title_format : nil)
+      
+      if member && !member.title_format.nil? && !member.title_format.empty?
+        string_path += file.formatted_name(member.title_format)
+      else
+        string_path += file.formatted_name(Setting.plugin_redmine_dmsf['dmsf_global_title_format'])
+      end
       @zip_file.put_next_entry(string_path)
       File.open(file.last_revision.disk_file, 'rb') do |f|
         while (buffer = f.read(8192))


### PR DESCRIPTION
Global title format, configured in plugin settings. Used when there is no user defined format.
Solves "1. global for all projects" of #547, probably not that hard to fix 2.