### PR TITLE
Global title format fixes

### DIFF
--- a/app/controllers/dmsf_files_controller.rb
+++ b/app/controllers/dmsf_files_controller.rb
@@ -52,8 +52,13 @@ class DmsfFilesController < ApplicationController
       access.action = DmsfFileRevisionAccess::DownloadAction
       access.save!
       member = Member.where(:user_id => User.current.id, :project_id => @file.project.id).first
+      if member && !member.title_format.nil? && !member.title_format.empty?
+        title_format = member.title_format
+      else
+        title_format = Setting.plugin_redmine_dmsf['dmsf_global_title_format']
+      end
       send_file(@revision.disk_file,
-        :filename => filename_for_content_disposition(@revision.formatted_name(member ? member.title_format : nil)),
+        :filename => filename_for_content_disposition(@revision.formatted_name(title_format)),
         :type => @revision.detect_content_type,
         :disposition => 'inline')
     rescue DmsfAccessError => e
@@ -84,8 +89,13 @@ class DmsfFilesController < ApplicationController
         access.action = DmsfFileRevisionAccess::DownloadAction
         access.save!
         member = Member.where(:user_id => User.current.id, :project_id => @file.project.id).first
+        if member && !member.title_format.nil? && !member.title_format.empty?
+          title_format = member.title_format
+        else
+          title_format = Setting.plugin_redmine_dmsf['dmsf_global_title_format']
+        end
         send_file(@revision.disk_file,
-          :filename => filename_for_content_disposition(@revision.formatted_name(member ? member.title_format : nil)),
+          :filename => filename_for_content_disposition(@revision.formatted_name(title_format)),
           :type => @revision.detect_content_type,
           :disposition => 'attachment')
       rescue DmsfAccessError => e

--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -403,10 +403,17 @@ class DmsfFile < ActiveRecord::Base
   end
 
   def display_name
-    if self.name.length > 50
-      return "#{self.name[0, 25]}...#{self.name[-25, 25]}"
+    member = Member.where(:user_id => User.current.id, :project_id => self.project.id).first
+    if member && !member.title_format.nil? && !member.title_format.empty?
+      title_format = member.title_format
+    else
+      title_format = Setting.plugin_redmine_dmsf['dmsf_global_title_format']
     end
-    self.name
+    fname = formatted_name(title_format)
+    if fname.length > 50
+      return "#{fname[0, 25]}...#{fname[-25, 25]}"
+    end
+    fname
   end
 
   def image?

--- a/app/models/dmsf_file_revision.rb
+++ b/app/models/dmsf_file_revision.rb
@@ -257,13 +257,14 @@ class DmsfFileRevision < ActiveRecord::Base
     else
       filename = self.name
     end
-    format.sub!('%t', self.title)
-    format.sub!('%f', filename)
-    format.sub!('%d', self.updated_at.strftime('%Y%m%d%H%M%S'))
-    format.sub!('%v', self.version)
-    format.sub!('%i', self.dmsf_file.id.to_s)
-    format.sub!('%r', self.id.to_s)
-    format + ext
+    format2 = format.dup
+    format2.sub!('%t', self.title)
+    format2.sub!('%f', filename)
+    format2.sub!('%d', self.updated_at.strftime('%Y%m%d%H%M%S'))
+    format2.sub!('%v', self.version)
+    format2.sub!('%i', self.dmsf_file.id.to_s)
+    format2.sub!('%r', self.id.to_s)
+    format2 + ext
   end
 
   def self.create_digest(path)

--- a/app/models/dmsf_link.rb
+++ b/app/models/dmsf_link.rb
@@ -98,7 +98,7 @@ class DmsfLink < ActiveRecord::Base
 
   def path
     if self.target_type == DmsfFile.model_name.to_s
-      path = self.target_file.dmsf_path.map { |element| element.is_a?(DmsfFile) ? element.name : element.title }.join('/') if self.target_file
+      path = self.target_file.dmsf_path.map { |element| element.is_a?(DmsfFile) ? element.display_name : element.title }.join('/') if self.target_file
     else
       path = self.target_folder ? self.target_folder.dmsf_path_str : ''
     end


### PR DESCRIPTION
Found out that when downloading a file the global title format were set to the name of the downloaded file. Turns out that the DmsfFileRevision.formatted_name method was working directly on the 'format' argument.

Also the global title format was not used when viewing a file or downloading a revision.
The DmsfFile.display_name has been changed to also use the global or user title format, consistent with the tooltip that shows when hovering the filename in the listview "Filename used for download or in Zip archive". Same for links to files.

Example with the title format set to "#%ir%r_%t_%v":
![image](https://cloud.githubusercontent.com/assets/13761538/20605853/b9037c14-b26d-11e6-913a-1f2aacef69f5.png)
