### PR TITLE
API extension: allow calling save action from api, extend show action so that it can be used to confirm folder existence

### DIFF
--- a/app/controllers/dmsf_controller.rb
+++ b/app/controllers/dmsf_controller.rb
@@ -29,7 +29,7 @@ class DmsfController < ApplicationController
   before_filter :find_parent, :only => [:new, :create]
   before_filter :tree_view, :only => [:delete, :show]
 
-  accept_api_auth :show, :create
+  accept_api_auth :show, :create, :save
 
   helper :all
 
@@ -180,6 +180,8 @@ class DmsfController < ApplicationController
 
     saved = @folder.save
 
+
+
     respond_to do |format|
       format.js
       format.api  {
@@ -223,11 +225,21 @@ class DmsfController < ApplicationController
       end
     end
 
-    if @folder.save
-      flash[:notice] = l(:notice_folder_details_were_saved)
-      redirect_to dmsf_folder_path(:id => @project, :folder_id => @folder)
-    else
-      render :action => 'edit'
+    saved = @folder.save
+    respond_to do |format|
+      format.api  {
+        unless saved
+          render_validation_errors(@folder)
+        end
+      }
+      format.html {
+        if saved
+          flash[:notice] = l(:notice_folder_details_were_saved)
+          redirect_to dmsf_folder_path(:id => @project, :folder_id => @folder)
+        else
+          render :action => 'edit'
+        end
+      }
     end
   end
 
@@ -667,3 +679,4 @@ class DmsfController < ApplicationController
   end
 
 end
+

--- a/app/views/dmsf/save.api.rsb
+++ b/app/views/dmsf/save.api.rsb
@@ -1,0 +1,5 @@
+api.dmsf_folder do
+  api.id @folder.id
+  api.title @folder.title
+  api.description @folder.description
+end

--- a/app/views/dmsf/show.api.rsb
+++ b/app/views/dmsf/show.api.rsb
@@ -29,4 +29,12 @@ api.dmsf do
       end
     end
   end
+
+  if @folder
+    api.found_folder do
+      api.id @folder.id
+      api.title @folder.title
+    end
+  end
+
 end

--- a/extra/api/api_client.sh
+++ b/extra/api/api_client.sh
@@ -41,3 +41,40 @@ curl -v -H "Content-Type: application/xml" -X GET -u ${1}:${2} http://localhost:
 # 4. Upload a document into a given folder or the root folder
 #curl --data-binary "@cat.gif" -H "Content-Type: application/octet-stream" -X POST -u ${1}:${2} http://localhost:3000/projects/12/dmsf/upload.xml?filename=cat.gif
 #curl -v -H "Content-Type: application/xml" -X POST --data "@file.xml" -u ${1}:${2} http://localhost:3000/projects/12/dmsf/commit.xml
+
+# 5. list folder contents & check folder existence (by folder title)
+# curl -v -H "Content-Type: application/json" -X GET -H "X-Redmine-API-Key: USERS_API_KEY" http://localhost:3000/projects/1/dmsf.json?folder_title=Updated%20title
+# 6. list folder contents & check folder existence (by folder id)
+# curl -v -H "Content-Type: application/json" -X GET -H "X-Redmine-API-Key: USERS_API_KE" http://localhost:3000/projects/1/dmsf.json?folder_id=3
+# both returns 404 not found, or json with following structure:
+# {  
+#   "dmsf":{  
+#      "dmsf_folders":[  
+#
+#      ],
+#      "total_count":0,
+#      "dmsf_files":[  
+#
+#      ],
+#      "dmsf_links":[  
+#
+#      ],
+#      "found_folder":{  
+#         "id":3,
+#         "title":"Updated title"
+#      }
+#   }
+#}
+
+# 7. update folder
+# curl -v -H "Content-Type: application/json" -X POST --data "@update-folder-payload.json" -H "X-Redmine-API-Key: USERS_API_KEY" http://localhost:3000//projects/#{project_id}/dmsf/save.json
+
+
+# update-folder-payload.json 
+#  {
+#     "dmsf_folder": {
+#       "title": title,
+#       "description": description
+#      },
+#      "folder_id": id                 -- id of folder to be updated
+#    }


### PR DESCRIPTION
Second attempt. Now pull request is to the correct branch (i hope) and i have also added examples how to use new functionality with CURL.

https://github.com/danmunn/redmine_dmsf/wiki/REST-API could also be updated accordingly, should i fork it and create pull request with documentation too ?