### PR TITLE
Fixed search error when description is nil.

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -68,7 +68,8 @@ class DmsfFile < ActiveRecord::Base
                   if desc
                     Redmine::Search.cache_store.delete("DmsfFile-#{o.id}")
                   else
-                    desc = o.description
+                    # Set desc to an empty string if o.description is nil
+                    desc = o.description.nil? ? "" : o.description
                     desc += ' / ' if o.description.present? && o.last_revision.comment.present?
                     desc += o.last_revision.comment if o.last_revision.comment.present?
                   end


### PR DESCRIPTION
If the file description is nil but the last commit comment is present then line 73 will fail since '+' is not defined for nil:NilClass.

This error was encountered when searching for documents and matching a document without a description but with a commit comment.
I did not see anything strange in the database for that particular file revision and I could not create another file that would cause the same error, maybe there is something else that is faulty?

Error message:
> 2017-01-11 16:17:12 +0100 INFO: Processing by SearchController#index as HTML
> 2017-01-11 16:17:12 +0100 INFO:   Parameters: {"utf8"=>"✓", "q"=>"Cost Overview 161209", "scope"=>"", "all_words"=>"1", "titles_only"=>"", "dmsf_files"=>"1", "commit"=>"Submit", "id"=>"myproject"}
> 2017-01-11 16:17:12 +0100 INFO:   Current user: redadmin (id=223)
> 2017-01-11 16:17:13 +0100 INFO:   Rendered plugins/redmine_xapian/app/views/search/index.html.erb within layouts/base (26.9ms)
> 2017-01-11 16:17:13 +0100 INFO: Completed 500 Internal Server Error in 145ms (ActiveRecord: 15.2ms)
> 2017-01-11 16:17:13 +0100 FATAL:
> ActionView::Template::Error (undefined method `+' for nil:NilClass):
>     82:           <% end %>
>     83:         <% # Plugin change end %>
>     84:         </dt>
>     85:         <dd><span class="description"><%= highlight_tokens(e.event_description, @tokens) %></span>
>     86:         <span class="author"><%= format_time(e.event_datetime) %></span></dd>
>     87:       <% end %>
>     88:     </dl>
>   plugins/redmine_dmsf/app/models/dmsf_file.rb:75:in `block in <class:DmsfFile>'
>   lib/plugins/acts_as_event/lib/acts_as_event.rb:62:in `event_description'
>   plugins/redmine_xapian/app/views/search/index.html.erb:85:in `block in _plugins_redmine_xapian_app_views_search_index_html_erb___1846478871570277849_35166120'
>   plugins/redmine_xapian/app/views/search/index.html.erb:71:in `each'
>   plugins/redmine_xapian/app/views/search/index.html.erb:71:in `_plugins_redmine_xapian_app_views_search_index_html_erb___1846478871570277849_35166120'
>   lib/redmine/sudo_mode.rb:63:in `sudo_mode'
