### PR TITLE
Disable versioning #630

### DIFF
--- a/app/views/settings/_dmsf_settings.html.erb
+++ b/app/views/settings/_dmsf_settings.html.erb
@@ -179,6 +179,14 @@
     <%= l(:note_webdav_ignore) %> <%= l(:label_default) %>: ^(\._|\.DS_Store$|Thumbs.db$)
   </em>
 </p>
+<p>
+  <%= content_tag(:label, l(:label_webdav_disable_versioning)) %>
+  <%= text_field_tag 'settings[dmsf_webdav_disable_versioning]', @settings['dmsf_webdav_disable_versioning'], :size => 50 %>
+  <em class="info">
+    <%= l(:note_webdav_disable_versioning) %> <br/>
+    <%= l(:label_default) %>: ^\~\$|\.tmp$
+  </em>
+</p>
 
 <hr/>
 <em class="info">

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -348,3 +348,6 @@ cs:
 
   label_document_url: Url
   label_last_revision_id: Revize
+  
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -345,3 +345,6 @@ de:
 
   label_webdav_ignore: Ignored files patterns
   note_webdav_ignore: A regular expresion with filenames to ignore by PUT requests.
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,3 +348,6 @@ en:
 
   label_document_url: Url
   label_last_revision_id: Revision
+  
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -348,3 +348,6 @@ es:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -348,3 +348,6 @@ fr:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -348,3 +348,6 @@ it: # Italian strings thx 2 Matteo Arceci!
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -348,3 +348,6 @@ ja:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -348,3 +348,6 @@ pl:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -348,3 +348,6 @@ pt-BR:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -348,3 +348,6 @@ ru:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -348,3 +348,6 @@ sl:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -348,3 +348,6 @@ zh-TW:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -348,3 +348,6 @@ zh:
 
   label_document_url: Url
   label_last_revision_id: Revision
+    
+  label_webdav_disable_versioning: No versioning files patterns
+  note_webdav_disable_versioning: A regular expression that disables versioning for matching files.

--- a/init.rb
+++ b/init.rb
@@ -49,7 +49,8 @@ Redmine::Plugin.register :redmine_dmsf do
               'dmsf_global_title_format' => '',
               'dmsf_columns' => %w(title size modified version workflow author),
               'dmsf_memcached_servers' => '',
-              'dmsf_webdav_ignore' => '^(\._|\.DS_Store$|Thumbs.db$)'
+              'dmsf_webdav_ignore' => '^(\._|\.DS_Store$|Thumbs.db$)',
+              'dmsf_webdav_disable_versioning' => '^\~\$|\.tmp$'
             }
   
   menu :project_menu, :dmsf, { :controller => 'dmsf', :action => 'show' }, :caption => :menu_dmsf, :before => :documents, :param => :id


### PR DESCRIPTION
Implemented disabling of file versioning as suggested in #630.

**Description**
When a file is stored (PUT) in WebDAV and its name matches the filter (regex in plugin settings) then only the initial revision is created and all subsequent stores reuse that revision and only replaces the file on disk. File revisions for the file can still be created using the WebGUI.

