### PR TITLE
webdav locked document

### DIFF
--- a/db/migrate/20170204214753_add_revision_to_dmsf_lock.rb
+++ b/db/migrate/20170204214753_add_revision_to_dmsf_lock.rb
@@ -1,0 +1,5 @@
+class AddRevisionToDmsfLock < ActiveRecord::Migration
+  def change
+    add_column :dmsf_locks, :revision, :integer
+  end
+end

--- a/lib/redmine_dmsf/lockable.rb
+++ b/lib/redmine_dmsf/lockable.rb
@@ -69,6 +69,7 @@ module RedmineDmsf
       l.lock_scope = scope
       l.user = User.current
       l.expires_at = expire
+      l.revision = self.last_revision.id unless self.is_a?(DmsfFolder)
       l.save!
       reload
       locks.reload

--- a/test/integration/webdav/dmsf_webdav_put_test.rb
+++ b/test/integration/webdav/dmsf_webdav_put_test.rb
@@ -204,6 +204,11 @@ class DmsfWebdavPutTest < RedmineDmsf::Test::IntegrationTest
         put "/dmsf/webdav/#{@project1.identifier}/test.txt", '1234', @jsmith.merge!({:content_type => :text})
         assert_response :success # 201 - Created
       end
+      # Second PUT on a locked file should only update the revision that were created on the first PUT
+      assert_no_difference 'file.dmsf_file_revisions.count' do
+        put "/dmsf/webdav/#{@project1.identifier}/test.txt", '1234', @jsmith.merge!({:content_type => :text})
+        assert_response :success # 201 - Created
+      end
     end
   end
 


### PR DESCRIPTION
A locked file only increase the revision once when it is updated/saved using WebDav. #615

When a file is locked the current file revision is stored with the lock.
When the file is updated via WebDav (PUT, or MOVE when doing MsOffice save sequence) the current file revision is compared to the revision stored in the lock, if they are the same a new revision is created but if they are not the same then a new revision has been created after the file was locked so reuse that revision.

So when working with files directly in the WebDav it will not spam new versions every time the user saves if the file is locked.