### PR TITLE
Webdav invalidate cache fixes

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -260,6 +260,9 @@ class DmsfFile < ActiveRecord::Base
         end
       end
     end
+    
+    # Must invalidate source parent folder cache before moving
+    RedmineDmsf::Webdav::Cache.invalidate_item(propfind_cache_key)
 
     self.container_type = self.container_type
     self.container_id = container.id

--- a/app/models/dmsf_file_revision.rb
+++ b/app/models/dmsf_file_revision.rb
@@ -270,7 +270,7 @@ class DmsfFileRevision < ActiveRecord::Base
     format2.sub!('%v', self.version)
     format2.sub!('%i', self.dmsf_file.id.to_s)
     format2.sub!('%r', self.id.to_s)
-    format2 + ext if ext
+    format2 += ext if ext
     format2
   end
 

--- a/lib/redmine_dmsf/lockable.rb
+++ b/lib/redmine_dmsf/lockable.rb
@@ -73,6 +73,12 @@ module RedmineDmsf
       l.save!
       reload
       locks.reload
+      
+      # Invalidate PROPFIND (for parent folder)
+      RedmineDmsf::Webdav::Cache.invalidate_item(self.propfind_cache_key)
+      # Invalidate PROPSTATS
+      RedmineDmsf::Webdav::Cache.delete("PROPSTATS/#{RedmineDmsf::Webdav::ProjectResource.create_project_name(self.project)}/#{self.dmsf_path_str}") if self.is_a?(DmsfFolder)
+      RedmineDmsf::Webdav::Cache.delete("PROPSTATS/#{self.id}-#{self.last_revision.id}") if self.is_a?(DmsfFile)
       return l
     end
 
@@ -136,6 +142,13 @@ module RedmineDmsf
           end
         end
       end
+      
+      # Invalidate PROPFIND (for parent folder)
+      RedmineDmsf::Webdav::Cache.invalidate_item(self.propfind_cache_key)
+      # Invalidate PROPSTATS 
+      RedmineDmsf::Webdav::Cache.delete("PROPSTATS/#{RedmineDmsf::Webdav::ProjectResource.create_project_name(self.project)}/#{self.dmsf_path_str}") if self.is_a?(DmsfFolder)
+      RedmineDmsf::Webdav::Cache.delete("PROPSTATS/#{self.id}-#{self.last_revision.id}") if self.is_a?(DmsfFile)
+      
       reload
       locks.reload
     end

--- a/lib/redmine_dmsf/webdav/dmsf_resource.rb
+++ b/lib/redmine_dmsf/webdav/dmsf_resource.rb
@@ -273,6 +273,9 @@ module RedmineDmsf
           if dest.exist?
             MethodNotAllowed
           else
+            # Must invalidate source parent folder cache before moving
+            RedmineDmsf::Webdav::Cache.invalidate_item(folder.propfind_cache_key)
+            
             if(parent.projectless_path == '/') #Project root
               folder.dmsf_folder_id = nil
             else
@@ -337,6 +340,8 @@ module RedmineDmsf
             else
               if (project == resource.project) && (file.last_revision.size == 0)
                 # Moving a zero sized file within the same project, just update the dmsf_folder
+                # Must invalidate source parent folder cache before moving
+                RedmineDmsf::Webdav::Cache.invalidate_item(file.propfind_cache_key)
                 file.dmsf_folder = f
               else
                 return InternalServerError unless file.move_to(resource.project, f)

--- a/lib/redmine_dmsf/webdav/project_resource.rb
+++ b/lib/redmine_dmsf/webdav/project_resource.rb
@@ -104,6 +104,13 @@ module RedmineDmsf
       def file
         nil
       end
+      
+      # Available properties
+      def properties
+        %w(creationdate displayname getlastmodified getetag resourcetype getcontenttype getcontentlength supportedlock lockdiscovery).collect do |prop|
+          {:name => prop, :ns_href => 'DAV:'}
+        end
+      end
 
       def project_id
 	      self.project.id if self.project


### PR DESCRIPTION
Fixed webdav cache invalidation when locking/unlocking #674
Fixed webdav cache invalidation when moving; the source folder were not invalidated so a ghost-item where left behind until the cache entry for the folder were invalidated because of other reasons.
Fixed so ProjectResource returns _supportedlock_ and _lockdiscovery_ for PROPFIND/allprop so that files and folders in the project root also can inform that they are locked.

Bonus: Fixed the fix for #657.
