### PR TITLE
expect .storage_path to return Pathname

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -99,7 +99,7 @@ class DmsfFile < ActiveRecord::Base
   def self.storage_path
     path = Setting.plugin_redmine_dmsf['dmsf_storage_directory']
     if path.blank?
-      path = Pathname.new('files').join('dmsf').to_s
+      path = Pathname.new('files').join('dmsf')
     else
       pn = Pathname.new(path)
       return pn if pn.absolute?


### PR DESCRIPTION
If currently running (Easy)Redmine haven't settings `Setting.plugin_redmine_dmsf['dmsf_storage_directory']` <#DmsfFileRevision> `storage_base_path` raise exception because expect  Pathname from DmsfFile => `DmsfFile.storage_path.join path`