### PR TITLE
uninstall fix

### DIFF
--- a/db/migrate/20170421101901_dmsf_file_container_rollback.rb
+++ b/db/migrate/20170421101901_dmsf_file_container_rollback.rb
@@ -69,7 +69,7 @@ class DmsfFileContainerRollback < ActiveRecord::Migration
 
   def down
     # dmsf_files
-    file_folder_ids = DmsfFile.joins(:dmsf_folder).where(:dmsf_folders => { :system => true }).pluck('dmsf_files.id, cast(dmsf_folders.title as int)')
+    file_folder_ids = DmsfFile.joins(:dmsf_folder).where(:dmsf_folders => { :system => true }).pluck('dmsf_files.id, cast(dmsf_folders.title as decimal)')
     remove_index :dmsf_files, :project_id
     rename_column :dmsf_files, :project_id, :container_id
     add_column :dmsf_files, :project_id, :int, :null => true # temporarily added for the save method


### PR DESCRIPTION
Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'int) FROM `dmsf_files` INNER JOIN `dmsf_folders` ON `dmsf_folders`.`id` = `dmsf_' at line 1: SELECT dmsf_files.id, cast(dmsf_folders.title as int) FROM `dmsf_files` INNER JOIN `dmsf_folders` ON `dmsf_folders`.`id` = `dmsf_files`.`dmsf_folder_id` WHERE `dmsf_folders`.`system` = 1