### PR TITLE
Added basic obsolete feature. It allows to obsolete revisions through…

### DIFF
--- a/after_init.rb
+++ b/after_init.rb
@@ -40,7 +40,7 @@ def init
                        :dmsf_folders_copy => [:new, :copy, :move],
                        :dmsf_context_menus => [:dmsf]}
       pmap.permission :file_manipulation,
-                      {:dmsf_files => [:create_revision, :lock, :unlock, :delete_revision, :notify_activate,
+                      {:dmsf_files => [:create_revision, :lock, :unlock, :delete_revision, :obsolete_revision, :notify_activate,
                                        :notify_deactivate, :restore],
                        :dmsf_upload => [:upload_files, :upload_file, :upload, :commit_files, :commit,
                                         :delete_dmsf_attachment, :delete_dmsf_link_attachment],

--- a/app/controllers/dmsf_files_controller.rb
+++ b/app/controllers/dmsf_files_controller.rb
@@ -23,8 +23,8 @@ class DmsfFilesController < ApplicationController
 
   menu_item :dmsf
 
-  before_action :find_file, :except => [:delete_revision]
-  before_action :find_revision, :only => [:delete_revision]
+  before_action :find_file, :except => [:delete_revision, :obsolete_revision]
+  before_action :find_revision, :only => [:delete_revision, :obsolete_revision]
   before_action :authorize
   before_action :tree_view, :only => [:delete]
   before_action :permissions
@@ -237,6 +237,18 @@ class DmsfFilesController < ApplicationController
           @file.save
         end
         flash[:notice] = l(:notice_revision_deleted)
+      else
+        flash[:error] = @revision.errors.full_messages.join(', ')
+      end
+    end
+    redirect_to :action => 'show', :id => @file
+  end
+
+  def obsolete_revision
+    if @revision
+      if @revision.obsolete()
+        flash[:notice] = l(:notice_revision_obsoleted)
+        log_activity('obsoleted')
       else
         flash[:error] = @revision.errors.full_messages.join(', ')
       end

--- a/app/models/dmsf_file_revision.rb
+++ b/app/models/dmsf_file_revision.rb
@@ -109,6 +109,16 @@ class DmsfFileRevision < ActiveRecord::Base
     end
   end
 
+  def obsolete()
+    if self.dmsf_file.locked_for_user?
+      errors[:base] << l(:error_file_is_locked)
+      return false
+    end
+    
+    self.workflow = DmsfWorkflow::STATE_OBSOLETE
+    save
+  end
+
   def restore
     self.deleted = DmsfFile::STATUS_ACTIVE
     self.deleted_by_user = nil
@@ -227,6 +237,8 @@ class DmsfFileRevision < ActiveRecord::Base
         str + l(:title_assigned)
       when DmsfWorkflow::STATE_REJECTED
         str + l(:title_rejected)
+      when DmsfWorkflow::STATE_OBSOLETE
+        str + l(:title_obsolete)
       else
         str + l(:title_none)
     end

--- a/app/models/dmsf_workflow.rb
+++ b/app/models/dmsf_workflow.rb
@@ -62,6 +62,7 @@ class DmsfWorkflow < ActiveRecord::Base
   STATE_WAITING_FOR_APPROVAL = 1
   STATE_APPROVED = 2
   STATE_REJECTED = 4
+  STATE_OBSOLETE = 5
 
   STATUS_LOCKED = 0
   STATUS_ACTIVE = 1
@@ -239,5 +240,5 @@ class DmsfWorkflow < ActiveRecord::Base
       end
     end
   end
-
+  
 end

--- a/app/views/dmsf_files/show.html.erb
+++ b/app/views/dmsf_files/show.html.erb
@@ -91,6 +91,10 @@
             delete_revision_path(revision),
             :data => {:confirm => l(:text_are_you_sure)},
             :title => l(:title_delete_revision) if @file_delete_allowed && (@file.dmsf_file_revisions.visible.count > 1) %>
+          <%= link_to image_tag('/../../plugin_assets/redmine_dmsf/images/obsolete.png'),
+            obsolete_revision_path(revision),
+            :data => {:confirm => l(:text_are_you_sure)},
+            :title => l(:title_obsolete_revision) if @file_delete_allowed && (revision.workflow == DmsfWorkflow::STATE_APPROVED) %>
         </div>
         <i><%= l(:info_revision, :rev => revision.id) %></i>
         <%= (revision.source_revision.nil? ? l(:label_created) : l(:label_changed)).downcase %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
   notice_file_deleted: File deleted
   error_at_least_one_revision_must_be_present: At least one revision must be present
   notice_revision_deleted: Revision deleted
+  notice_revision_obsoleted: Revision obsoleted
   warning_one_of_files_locked: One of files locked
   notice_file_revision_created: File revision created
   notice_your_preferences_were_saved: Your preferences were saved
@@ -115,6 +116,7 @@ en:
   heading_revisions: Revisions
   title_download: Download
   title_delete_revision: Delete revision
+  title_obsolete_revision: Obsolete revision
   label_created: Created
   label_changed: Changed
   info_changed_by_user: "%{changed} by"
@@ -270,6 +272,7 @@ en:
   title_assigned: Assigned
   title_approval: Approval
   title_rejected: Rejected
+  title_obsolete: Obsolete
   dmsf_and: AND
   dmsf_or: OR
   dmsf_new_step: New step

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -48,6 +48,7 @@ es:
   notice_file_deleted: Archivo borrado
   error_at_least_one_revision_must_be_present: al menos una revisión debe estar presente
   notice_revision_deleted: Revision eliminada correctamente
+  notice_revision_obsoleted: Revision obsoletada correctamente
   warning_one_of_files_locked: Uno de los archivos está bloqueado
   notice_file_revision_created: Revision de archivos creada correctamente
   notice_your_preferences_were_saved: Sus preferencias han sido guardadas correctamente
@@ -115,6 +116,7 @@ es:
   heading_revisions: Revisiones
   title_download: Descargar
   title_delete_revision: Eliminar revisión
+  title_obsolete_revision: Obsoletar revisión
   label_created: Creado
   label_changed: Modificado
   info_changed_by_user: "%{changed} por"
@@ -269,6 +271,7 @@ es:
   title_assigned: Asignado
   title_approval: Aprobar
   title_rejected: Rechazado
+  title_obsolete: Obsoleto
   dmsf_and: Y
   dmsf_or: O
   dmsf_new_step: Nuevo Paso

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ if Redmine::Plugin.installed? :redmine_dmsf
     post '/dmsf/files/:id/delete', :controller => 'dmsf_files', :action => 'delete', :as => 'delete_dmsf_files'
     post '/dmsf/files/:id/revision/create', :controller => 'dmsf_files', :action => 'create_revision'
     get '/dmsf/files/:id/revision/delete', :controller => 'dmsf_files', :action => 'delete_revision', :as => 'delete_revision'
+    get '/dmsf/files/:id/revision/obsolete', :controller => 'dmsf_files', :action => 'obsolete_revision', :as => 'obsolete_revision'
     get '/dmsf/files/:id/download', :to => 'dmsf_files#view', :download => '', :as => 'download_dmsf_file' # Otherwise will not route nil into the download param
     get '/dmsf/files/:id/view', :to => 'dmsf_files#view', :as => 'view_dmsf_file'
     get '/dmsf/files/:id', :controller => 'dmsf_files', :action => 'show', :as => 'dmsf_file'


### PR DESCRIPTION
Added basic obsolete feature. It allows to obsolete revisions through an forbidden icon next to the delete icon.

It only shows when the revision has been previously approved and the user has permission to delete revisions.

                   ------------------------------------------------
I did this pull request a while ago. At that time, you asked me to repeatre it against devel-1.6.1 but couldn't do it till today. Sorry for the delay, I'm doing it now against devel-1.6.2 instead. I hope you are still willing to merge it in.

Thanks,

   Pedro



Future improvements:
Include a new entry in the approval workflow history the user and time when the revision has been made obsolete.
Possibly, create a specific obsolete permission
Possibly, create a specific obsolete workflow