### PR TITLE
Added the ability to set a custom caption where referencing file details with the {{dmsfd(...)}} macro

### DIFF
--- a/lib/redmine_dmsf/macros.rb
+++ b/lib/redmine_dmsf/macros.rb
@@ -81,7 +81,7 @@ Redmine::WikiFormatting::Macros.register do
     raise ArgumentError if args.length < 1 # Requires file id
     file = DmsfFile.visible.find args[0].strip
     if User.current && User.current.allowed_to?(:view_dmsf_files, file.project)
-      return link_to file.title, dmsf_file_path(:id => file)
+      return link_to(h(args[1] ? args[1] : file.title), dmsf_file_path(:id => file))
     else
       raise l(:notice_not_authorized)
     end


### PR DESCRIPTION
Example:
`{{dmsfd(123, File details)}} -> <a href="/dmsf/files/123">File details</a>`

Background: I wanted, for the same file, to put two links together, one to the file view, one to the details (revisions).
I wanted the first link to have the file's title as the caption, while the second with a custom caption (like "Details"). But it happened that while it is possible to customize the caption for the link to file's view, we cannot customize the link to the file's revisions the same way, so I had two links with both the same caption being redundant and cumbersome (the file's title).