### PR TITLE
Feature: DMSF file's version and last update date macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,13 @@ Link to a document with id 17 with link text "File": `{{dmsf(17, File)}}`
 
 Link to the details of a document with id 17: `{{dmsfd(17)}}`
 
-Link to the description of a document with id 17: `{{dmsfdesc(17)}}`
+Link to the details of a document with id 17 with link text "Details": `{{dmsfd(17, Details)}}`
+
+Text of the description of a document with id 17: `{{dmsfdesc(17)}}`
+
+Text referring to the version of a document with id 17: `{{dmsfversion(17)}}`
+
+Text referring to the last update date of a document with id 17: `{{dmsflastupdate(17)}}`
 
 Link to the preview of 5 lines from a document with id 17: `{{dmsft(17, 5)}}`
 

--- a/lib/redmine_dmsf/macros.rb
+++ b/lib/redmine_dmsf/macros.rb
@@ -87,8 +87,8 @@ Redmine::WikiFormatting::Macros.register do
     end
   end
 
-  # dmsfdesc - link to the document's description
-  desc "Wiki link to DMSF document description:\n\n" +
+  # dmsfdesc - text referring to the document's description
+  desc "Text referring to DMSF document description:\n\n" +
          "{{dmsfdesc(document_id)}}\n\n" +
          "_document_id_ can be found in the document's details."
   macro :dmsfdesc do |obj, args|
@@ -96,6 +96,34 @@ Redmine::WikiFormatting::Macros.register do
     file = DmsfFile.visible.find args[0].strip
     if User.current && User.current.allowed_to?(:view_dmsf_files, file.project)
       return textilizable(file.description)
+    else
+      raise l(:notice_not_authorized)
+    end
+  end
+
+  # dmsfversion - text referring to the document's version
+  desc "Text referring to DMSF document version:\n\n" +
+         "{{dmsfversion(document_id)}}\n\n" +
+         "_document_id_ can be found in the document's details."
+  macro :dmsfversion do |obj, args|
+    raise ArgumentError if args.length < 1 # Requires file id
+    file = DmsfFile.visible.find args[0].strip
+    if User.current && User.current.allowed_to?(:view_dmsf_files, file.project)
+      return textilizable(file.version)
+    else
+      raise l(:notice_not_authorized)
+    end
+  end
+
+  # dmsflastupdate - text referring to the document's last update date
+  desc "Text referring to DMSF document last update date:\n\n" +
+         "{{dmsflastupdate(document_id)}}\n\n" +
+         "_document_id_ can be found in the document's details."
+  macro :dmsflastupdate do |obj, args|
+    raise ArgumentError if args.length < 1 # Requires file id
+    file = DmsfFile.visible.find args[0].strip
+    if User.current && User.current.allowed_to?(:view_dmsf_files, file.project)
+      return textilizable(format_time(file.last_revision.updated_at))
     else
       raise l(:notice_not_authorized)
     end


### PR DESCRIPTION
Added macros to reference a file's version and last update date in Wiki:

    Example:
        {{dmsfversion(123)}} -> "2.5" -> return version of file with id "123"
        {{dmsflastupdate(123)}} -> "2018-08-24 08:46" -> returns the file's last update date (formatted according to redmine settings)

**Background:**
I wanted to reference those pieces of information to include them in a Wiki table (formatted with textile or markdown) featuring each file with its current version and last update date. I find that useful when used in this kind of recap table, referring to a whole set of files needed by different kinds of members in a given project (documentation, manuals, etc.).
<pre>+--------------------+---------+------------------+
| File               | Version | Last Update      |
+--------------------+---------+------------------+
| My file 1          | 2.5     | 2018-08-24 08:46 |
| My file 2          | 2.2     | 2018-08-21 07:41 |
+--------------------+---------+------------------+`</pre>