### PR TITLE
fix uninitialized constant Redmine::IntegrationTest NameError

### DIFF
--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -23,7 +23,7 @@ module RedmineDmsf
   module Test
     class IntegrationTest < Redmine::IntegrationTest
       def self.fixtures(*table_names)
-        dir = File.join( File.dirname(__FILE__), '../../../test/fixtures')
+        dir = File.join( File.dirname(__FILE__), '/fixtures')
         table_names.each do |x|          
           ActiveRecord::FixtureSet.create_fixtures(dir, x) if File.exist?("#{dir}/#{x}.yml")
         end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -28,7 +28,7 @@ module RedmineDmsf
       # Ultimately it allows for better integration without blowing redmine fixtures up,
       # and allowing us to suppliment redmine fixtures if we need to.
       def self.fixtures(*table_names)
-        dir = File.join( File.dirname(__FILE__), '../../../test/fixtures')
+        dir = File.join( File.dirname(__FILE__), '/fixtures')
         table_names.each do |x|
           ActiveRecord::FixtureSet.create_fixtures(dir, x) if File.exist?("#{dir}/#{x}.yml")
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,3 +22,7 @@
 
 # Load the normal Rails helper
 require File.expand_path('../../../../test/test_helper', __FILE__)
+
+require_relative 'test_case'
+require_relative 'integration_test'
+require_relative 'unit_test'

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -28,7 +28,7 @@ module RedmineDmsf
       # Ultimately it allows for better integration without blowing redmine fixtures up,
       # and allowing us to suppliment redmine fixtures if we need to.
       def self.fixtures(*table_names)
-        dir = File.join( File.dirname(__FILE__), '../../../test/fixtures')
+        dir = File.join( File.dirname(__FILE__), '/fixtures')
         table_names.each do |x|
           ActiveRecord::FixtureSet.create_fixtures(dir, x) if File.exist?("#{dir}/#{x}.yml")
         end


### PR DESCRIPTION
this is a minimal patch for the eager loading problem in redmine 4.0.3 see http://www.redmine.org/issues/30753

discussed in https://github.com/danmunn/redmine_dmsf/issues/984 and https://github.com/danmunn/redmine_dmsf/issues/992
