### PR TITLE
fix deprecation multiple gemfile sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-source 'https://rubygems.org'
-
 gem 'rubyzip', '>= 1.1.3'
 gem 'zip-zip'
 gem 'simple_enum'


### PR DESCRIPTION
[DEPRECATED] Your Gemfile contains multiple primary sources. Using `source` more than once without a block is a security risk, and may result in installing unexpected gems. To resolve this warning, use a block to indicate which gems should come from the secondary source. To upgrade this warning to an error, run `bundle config set disable_multisource true`.