### PR TITLE
Fix wrong query helper patching

### DIFF
--- a/lib/redmine_dmsf/patches/queries_helper_patch.rb
+++ b/lib/redmine_dmsf/patches/queries_helper_patch.rb
@@ -154,5 +154,5 @@ module RedmineDmsf
   end
 end
 
-RedmineExtensions::PatchManager.register_helper_patch 'QueriesHelper',
+RedmineExtensions::PatchManager.register_helper_patch 'ProjectsQueriesHelper',
   'RedmineDmsf::Patches::QueriesHelperPatch', prepend: true


### PR DESCRIPTION
I found a bug associated with query helper patching.

IMHO, we need to use `ProjectsQueriesHelper` instead of `QueriesHelper` as far as DMS view has changed.

Signed-off-by: Ji-Hyeon Gim <potatogim@gluesys.com>