### PR TITLE
ruby 2.3 compatibility

### DIFF
--- a/lib/redmine_dmsf/hooks/views/base_view_hooks.rb
+++ b/lib/redmine_dmsf/hooks/views/base_view_hooks.rb
@@ -26,13 +26,13 @@ module RedmineDmsf
 
       # TODO: *.css are twice there
       def view_layouts_base_html_head(context={})
-        return unless context[:controller].class.name.match?(/^(Dmsf|Projects)/)
+        return unless /^(Dmsf|Projects)/.match?(context[:controller].class.name)
         meta = "\n".html_safe + stylesheet_link_tag('redmine_dmsf.css', plugin: :redmine_dmsf) +
         "\n".html_safe + stylesheet_link_tag('select2.min.css', plugin: :redmine_dmsf) +
         "\n".html_safe + javascript_include_tag('select2.min.js', plugin: :redmine_dmsf, defer: true) +
         "\n".html_safe + javascript_include_tag('redmine_dmsf.js', plugin: :redmine_dmsf, defer: true) +
         "\n".html_safe + javascript_include_tag('attachments_dmsf.js', plugin: :redmine_dmsf, defer: true)
-        if defined?(EasyExtensions) && context[:controller].class.name.match?(/^Dmsf/)
+        if defined?(EasyExtensions) && /^Dmsf/.match?(context[:controller].class.name)
           meta << "\n".html_safe + javascript_include_tag('context_menu', 'application', defer: true)
         end
         meta


### PR DESCRIPTION
even if it's EOL, Redmine still do support Ruby 2.3

```
undefined method `match?' for "IssuesController":String
```

the fix is simple, it works because Rails has a compatibility extension on Regexes, but it's still undefined on Strings
https://github.com/rails/rails/blob/5-2-stable/activesupport/lib/active_support/core_ext/regexp.rb#L8