### PR TITLE
restore minimum Redmine version to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,9 @@ after_script:
   - bash -x ./test/ci/redmine_install.sh -u
 
 env:
+  - DB=sqlite   REDMINE_GIT_TAG=4.0-stable
+  - DB=mysql    REDMINE_GIT_TAG=4.0-stable
+  - DB=postgres REDMINE_GIT_TAG=4.0-stable
   - DB=sqlite   REDMINE_GIT_TAG=4.1-stable
   - DB=mysql    REDMINE_GIT_TAG=4.1-stable
   - DB=postgres REDMINE_GIT_TAG=4.1-stable

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Features
   * Documents and folders symbolic links  
   * Trash bin
   * Documents attachable to issues
-  * Compatible with Redmine 4.1.x
+  * Compatible with Redmine 4.0.x and 4.1.x
 
 Dependencies
 ------------
   
-  * Redmine 4.1.0 or higher
+  * Redmine 4.0.0 or higher
 
 ### Full-text search (optional)
 

--- a/init.rb
+++ b/init.rb
@@ -35,7 +35,7 @@ Redmine::Plugin.register :redmine_dmsf do
   description 'Document Management System Features'
   version '2.4.3'
   
-  requires_redmine version_or_higher: '4.1.0'
+  requires_redmine version_or_higher: '4.0.0'
 
   settings partial: 'settings/dmsf_settings',
             default: {


### PR DESCRIPTION
fixes https://github.com/danmunn/redmine_dmsf/issues/1131

I don't think there's a reason why we can't support redmine 4.0... let's restore it

btw: travis seems to be broken on this repository