### PR TITLE
[webdav] add content type for html reponses

### DIFF
--- a/lib/redmine_dmsf/webdav/dmsf_resource.rb
+++ b/lib/redmine_dmsf/webdav/dmsf_resource.rb
@@ -200,6 +200,7 @@ module RedmineDmsf
         if collection?
           html_display
           response['Content-Length'] = response.body.bytesize.to_s
+          response['Content-Type'] = 'text/html'
         else
           raise Forbidden unless User.current.admin? || User.current.allowed_to?(:view_dmsf_files, project)
           response.body = download # Rack based provider

--- a/lib/redmine_dmsf/webdav/index_resource.rb
+++ b/lib/redmine_dmsf/webdav/index_resource.rb
@@ -68,6 +68,7 @@ module RedmineDmsf
       def get(request, response)
         html_display
         response['Content-Length'] = response.body.bytesize.to_s
+        response['Content-Type'] = 'text/html'
         OK
       end
 

--- a/lib/redmine_dmsf/webdav/project_resource.rb
+++ b/lib/redmine_dmsf/webdav/project_resource.rb
@@ -97,6 +97,7 @@ module RedmineDmsf
       def get(request, response)
         html_display
         response['Content-Length'] = response.body.bytesize.to_s
+        response['Content-Type'] = 'text/html'
         OK
       end
 

--- a/test/integration/webdav/dmsf_webdav_get_test.rb
+++ b/test/integration/webdav/dmsf_webdav_get_test.rb
@@ -41,6 +41,13 @@ class DmsfWebdavGetTest < RedmineDmsf::Test::IntegrationTest
     assert_response :success
   end
 
+  def test_should_include_response_headers
+    get '/dmsf/webdav', params: nil, headers: @admin
+    assert_response :success
+    assert_equal 'text/html', response.headers['Content-Type']
+    assert response.headers['Content-Length'].to_i > 0, "Content-Length should be > 0, but was #{response.headers['Content-Length']}"
+  end
+
   def test_should_list_dmsf_enabled_project
     get '/dmsf/webdav', params: nil, headers: @admin
     assert_response :success


### PR DESCRIPTION
fixes a case when browsers display a plain text instead of HTML