### PR TITLE
Highlight admin menu item and very little fix of ProjectPatch#copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /test/fixtures/files/**
 !/test/fixtures/files/2017/**
 Gemfile.lock
+.history

--- a/app/controllers/dmsf_workflows_controller.rb
+++ b/app/controllers/dmsf_workflows_controller.rb
@@ -22,6 +22,7 @@
 class DmsfWorkflowsController < ApplicationController
 
   model_object DmsfWorkflow
+  menu_item :dmsf_approvalworkflows
 
   before_action :find_model_object, except: [:create, :new, :index, :assign, :assignment]
   before_action :find_project

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -318,7 +318,7 @@ de:
   label_links_only: nur Verknüpfungen
 
   label_display_notified_recipients: Zeige benachrichtigte Empfänger
-  note_display_notified_recipients: Der Benutzer wird darüber informiert, wer die Empfänger der E-mail-Benachrichtigungen sind.
+  note_display_notified_recipients: Der Benutzer wird darüber informiert, wer die Empfänger der E-Mail-Benachrichtigungen sind.
   warning_email_notifications: "E-Mailbenachrichtigung wurde gesendet an %{to}"
 
   link_trash_bin: Papierkorb

--- a/lib/redmine_dmsf/patches/project_patch.rb
+++ b/lib/redmine_dmsf/patches/project_patch.rb
@@ -39,6 +39,8 @@ module RedmineDmsf
             send "copy_#{name}", project
           end
           save
+        else   
+          false
         end
       end
 


### PR DESCRIPTION
Hi Karel,

I fixed two small but effective issus in your plugin:

1. Highlighting of admin menu item for dmsf_workflows
2. Redmine core test failure due to missing boolean return value in RedmineDmsf::Patches::ProjectPatch#copy

Perhaps you'd like to share it with the community?

Best Regards,
Liane

PS: The branch contains patches you had already merged. Sorry for that. I will try to avoid this in the future!