### PR TITLE
Allow approval workflow actions only on x.0 file versions

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -110,6 +110,14 @@ class DmsfFile < ActiveRecord::Base
     visible.find_by project_id: project_id, dmsf_folder_id: folder&.id, name: name
   end
 
+  def approval_allowed_zero_minor
+    if Setting.plugin_redmine_dmsf['only_approval_zero_minor_version'] 
+      return last_revision.minor_version == 0
+    else
+      return true
+    end
+  end
+
   def last_revision
     unless defined?(@last_revision)
       @last_revision = deleted? ? dmsf_file_revisions.first : dmsf_file_revisions.visible.first

--- a/app/views/dmsf_context_menus/_approval_workflow.html.erb
+++ b/app/views/dmsf_context_menus/_approval_workflow.html.erb
@@ -22,8 +22,9 @@
 
 <% workflows_available = DmsfWorkflow.where(['project_id = ? OR project_id IS NULL', project.id]).exists? %>
 <% wf = DmsfWorkflow.find_by(id: dmsf_file.last_revision.dmsf_workflow_id) if dmsf_file.last_revision.dmsf_workflow_id %>
-<% file_approval_allowed = User.current.allowed_to?(:file_approval, project) && (dmsf_file.approval_allowed_zero_minor)%>
+<% file_approval_allowed = User.current.allowed_to?(:file_approval, project) %>
 <% allowed = User.current && (dmsf_file.last_revision.dmsf_workflow_assigned_by_user == User.current) && wf %>
+<% allowed_minor = dmsf_file.approval_allowed_zero_minor %>
 
 <% if file_approval_allowed %>
   <% case dmsf_file.last_revision.workflow %>
@@ -32,22 +33,43 @@
           <% assignments = wf.next_assignments(dmsf_file.last_revision.id) %>
           <% index = assignments.find_index{ |assignment| assignment.user_id == User.current.id } if assignments %>
           <% assignment_id = (index && assignments && assignments[index]) ? assignments[index].id : nil %>
-          <%= context_menu_link l(:title_approval), action_dmsf_workflow_path(project_id: project.id, id: wf.id,
+          <% if allowd_minor %>
+            <%= context_menu_link l(:title_approval), action_dmsf_workflow_path(project_id: project.id, id: wf.id,
                                 dmsf_workflow_step_assignment_id: assignment_id,
                                 dmsf_file_revision_id: dmsf_file.last_revision.id),
                                 remote: true, class: 'icon icon-ok', id: 'dmsf-cm-workflow',
                                 disabled: !assignments || !index %>
+          <% else %>
+            <%= context_menu_link l(:title_approval_minor), action_dmsf_workflow_path(project_id: project.id, id: wf.id,
+                                dmsf_workflow_step_assignment_id: assignment_id,
+                                dmsf_file_revision_id: dmsf_file.last_revision.id),
+                                remote: true, class: 'icon icon-ok', id: 'dmsf-cm-workflow',
+                                disabled: true %>
+          <% end %>
       <% end %>
     <% when DmsfWorkflow::STATE_ASSIGNED %>
-      <%= context_menu_link l(:title_start), start_dmsf_workflow_path(id: dmsf_file.last_revision.dmsf_workflow_id,
+      <% if allowd_minor %>
+        <%= context_menu_link l(:title_start), start_dmsf_workflow_path(id: dmsf_file.last_revision.dmsf_workflow_id,
                             dmsf_file_revision_id: dmsf_file.last_revision.id),
                             class: 'icon icon-ok', disabled: !allowed %>
+      <% else %>
+        <%= context_menu_link l(:title_start_minor), start_dmsf_workflow_path(id: dmsf_file.last_revision.dmsf_workflow_id,
+                            dmsf_file_revision_id: dmsf_file.last_revision.id),
+                            class: 'icon icon-ok', disabled: true %>
+      <% end %>
     <% when DmsfWorkflow::STATE_APPROVED, DmsfWorkflow::STATE_REJECTED, DmsfWorkflow::STATE_OBSOLETE %>
         <%# %>
     <% else %>
-        <%= context_menu_link l(:title_assignment), assign_dmsf_workflow_path(id: project.id, project_id: project.id,
+        <% if allowed_minor %>
+            <%= context_menu_link l(:title_assignment), assign_dmsf_workflow_path(id: project.id, project_id: project.id,
                               dmsf_file_revision_id: dmsf_file.last_revision.id),
                               remote: true, class: 'icon icon-ok', id: 'dmsf-cm-workflow',
                               disabled: locked || !workflows_available %>
+        <% else %>
+            <%= context_menu_link l(:title_assignment_minor), assign_dmsf_workflow_path(id: project.id, project_id: project.id,
+                              dmsf_file_revision_id: dmsf_file.last_revision.id),
+                              remote: true, class: 'icon icon-ok', id: 'dmsf-cm-workflow',
+                              disabled: true %>
+        <% end %>
     <% end %>
 <% end %>

--- a/app/views/dmsf_context_menus/_approval_workflow.html.erb
+++ b/app/views/dmsf_context_menus/_approval_workflow.html.erb
@@ -33,7 +33,7 @@
           <% assignments = wf.next_assignments(dmsf_file.last_revision.id) %>
           <% index = assignments.find_index{ |assignment| assignment.user_id == User.current.id } if assignments %>
           <% assignment_id = (index && assignments && assignments[index]) ? assignments[index].id : nil %>
-          <% if allowd_minor %>
+          <% if allowed_minor %>
             <%= context_menu_link l(:title_approval), action_dmsf_workflow_path(project_id: project.id, id: wf.id,
                                 dmsf_workflow_step_assignment_id: assignment_id,
                                 dmsf_file_revision_id: dmsf_file.last_revision.id),
@@ -48,7 +48,7 @@
           <% end %>
       <% end %>
     <% when DmsfWorkflow::STATE_ASSIGNED %>
-      <% if allowd_minor %>
+      <% if allowed_minor %>
         <%= context_menu_link l(:title_start), start_dmsf_workflow_path(id: dmsf_file.last_revision.dmsf_workflow_id,
                             dmsf_file_revision_id: dmsf_file.last_revision.id),
                             class: 'icon icon-ok', disabled: !allowed %>

--- a/app/views/dmsf_context_menus/_approval_workflow.html.erb
+++ b/app/views/dmsf_context_menus/_approval_workflow.html.erb
@@ -22,7 +22,7 @@
 
 <% workflows_available = DmsfWorkflow.where(['project_id = ? OR project_id IS NULL', project.id]).exists? %>
 <% wf = DmsfWorkflow.find_by(id: dmsf_file.last_revision.dmsf_workflow_id) if dmsf_file.last_revision.dmsf_workflow_id %>
-<% file_approval_allowed = User.current.allowed_to?(:file_approval, project) %>
+<% file_approval_allowed = User.current.allowed_to?(:file_approval, project) && (dmsf_file.approval_allowed_zero_minor)%>
 <% allowed = User.current && (dmsf_file.last_revision.dmsf_workflow_assigned_by_user == User.current) && wf %>
 
 <% if file_approval_allowed %>

--- a/app/views/settings/_dmsf_settings.html.erb
+++ b/app/views/settings/_dmsf_settings.html.erb
@@ -200,6 +200,14 @@
   </em>
 </p>
 
+<p>
+  <%= content_tag(:label, l(:only_approval_zero_minor_version)) %>
+  <%= check_box_tag 'settings[only_approval_zero_minor_version]', false, @settings['only_approval_zero_minor_version'], size: 50 %>
+  <em class="info">
+    <%= l(:only_approval_zero_minor_version) %><br/> <%= l(:label_default) %>: <%= l(:general_text_No)%>
+  </em>
+</p>
+
 <hr/>
 <em class="info">
   <%= l(:label_webdav) %>
@@ -315,3 +323,5 @@
     <%= l(:text_enable_cjk_ngrams) %>
   </em>
 </p>
+
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,10 +254,13 @@ en:
   title_rejection: Rejection
   title_delegation: Delegation
   title_assignment: Assignment
+  title_assignment_minor: Assignment not allowed, minor != 0
   title_start: Start
+  title_start_minor: Start not allowed, minor != 0
   title_dmsf_workflow_log: Approval Workflow Log
   title_assigned: Assigned
   title_approval: Approval
+  title_approval_minor: Approval not allowed, minor != 0
   title_rejected: Rejected
   title_obsolete: Obsolete
   dmsf_and: AND

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,13 +254,13 @@ en:
   title_rejection: Rejection
   title_delegation: Delegation
   title_assignment: Assignment
-  title_assignment_minor: Assignment not allowed, minor != 0
+  title_assignment_minor: Assignment not allowed, minor must be zero 
   title_start: Start
-  title_start_minor: Start not allowed, minor != 0
+  title_start_minor: Start not allowed, minor must be zero
   title_dmsf_workflow_log: Approval Workflow Log
   title_assigned: Assigned
   title_approval: Approval
-  title_approval_minor: Approval not allowed, minor != 0
+  title_approval_minor: Approval not allowed, minor must be zero
   title_rejected: Rejected
   title_obsolete: Obsolete
   dmsf_and: AND

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -422,3 +422,4 @@ en:
     errors:
       messages:
         error_contains_invalid_character: contains invalid character(s)
+  only_approval_zero_minor_version: only approval zero minor version


### PR DESCRIPTION
Hi,

in our company it is only allowed to approve documents which have the version 1.0, 2.0, ... x.0, in other words, the minor version must be zero when approving a document.

I created a configurable option to accomplish the aforementioned behavior. The default settings is such that the change is backwards compatible.

Could you please check if the code is correct and delivers actual value to redmine_dmsf?
I also changed text configuration files, but I do not have translations for the other locales other than English.

Br
Carl.

