### PR TITLE
Fix HTTP Status 500 when emailing document link

### DIFF
--- a/app/views/dmsf_mailer/send_documents.html.erb
+++ b/app/views/dmsf_mailer/send_documents.html.erb
@@ -34,7 +34,7 @@
           <% dir = DmsfFolder.find_by(id: i) %>
           <% if dir && !folders.include?(dir) %>
             <br/>
-            <%= link_to h(dir.dmsf_path_str), dmsf_folder_path(id: dir.project_id, folder_id: dir.id, only_path: false) %>
+            <%= link_to h(dir.dmsf_path_str), dmsf_folder_url(id: dir.project_id, folder_id: dir.id, only_path: false) %>
             <br/><br/>
             <% dir.dmsf_files.each do |file| %>
               <% unless files.include?(file) %>


### PR DESCRIPTION
When any user tries to send a document link via email the user will get
an error page with HTTP Status 500. This error can be fixed with
using the url helper for link building.