### PR TITLE
Remove a drive letter when using WebDAV in Windows

### DIFF
--- a/lib/dav4rack/request.rb
+++ b/lib/dav4rack/request.rb
@@ -143,6 +143,8 @@ module Dav4rack
       collection = path.end_with?('/')
       path = ::File.expand_path path
       path << '/' if collection and !path.end_with?('/')
+      # remove a drive letter in Windows
+      path.gsub!(/^([^\/]*)\//, '/')
       path
     end
 


### PR DESCRIPTION
When using WebDAV on Windows, `WebDAV Error: path must be present and start with a /` error is occurred.
Like this:
```
I, [2022-05-17T20:21:04.015308 #35216]  INFO -- : [21937270-ef15-48d5-a01d-89c9e3447f53] Started PUT "/redmine/dmsf/webdav/project_a/test_image.png" for 127.0.0.1 at 2022-05-17 20:21:04 +0900
I, [2022-05-17T20:21:04.016944 #35216]  INFO -- : [21937270-ef15-48d5-a01d-89c9e3447f53] Processing WebDAV request: /redmine/dmsf/webdavC:/project_a/test_image.png (for 127.0.0.1 at 2022-05-17 20:21:04 +0900) [PUT]
E, [2022-05-17T20:21:04.019454 #35216] ERROR -- : [21937270-ef15-48d5-a01d-89c9e3447f53] WebDAV Error: path must be present and start with a /
E, [2022-05-17T20:21:04.019730 #35216] ERROR -- : [21937270-ef15-48d5-a01d-89c9e3447f53] path must be present and start with a /
```

I found that the `Dav4rack::Request#expand_path` method adds the drive letter to the head of the path as follows: `C:/project_a/test_image.png`.
So, I tried to fix it.

- Environment
    - Windows 11 21H2
    - Bitnami Redmine 5.0.0-0