### PR TITLE
Replacing view_dmsf_file_path references with view_dmsf_file_url

### DIFF
--- a/app/views/dmsf_files/_link.html.erb
+++ b/app/views/dmsf_files/_link.html.erb
@@ -36,7 +36,7 @@
 </td>
 <td class="<%= cls %>">
   <span class="size">(<%= number_to_human_size dmsf_file.last_revision.size %>)</span>
-  <%= link_to '', view_dmsf_file_path(dmsf_file, download: dmsf_file.last_revision, disposition: 'attachment'),
+  <%= link_to '', view_dmsf_file_url(dmsf_file, download: dmsf_file.last_revision, disposition: 'attachment'),
         title: l(:title_title_version_version_download, title: h(dmsf_file.last_revision.title),
         version: dmsf_file.last_revision.version), class: 'icon icon-download dmsf-revision-action-button' %>
 </td>

--- a/app/views/dmsf_files/_thumbnails.html.erb
+++ b/app/views/dmsf_files/_thumbnails.html.erb
@@ -30,10 +30,10 @@
           <% images.each do |file| %>
               <div>
                 <% if link_to # Redmine classic %>
-                    <%= link_to image_tag(dmsf_thumbnail_path(file), alt: file.title), view_dmsf_file_path(file) %>
+                    <%= link_to image_tag(dmsf_thumbnail_path(file), alt: file.title), view_dmsf_file_url(file) %>
                 <% else # jQuery gallery %>
                     <%= image_tag(dmsf_thumbnail_path(file),
-                      { :'data-fullsrc' => view_dmsf_file_path(file), alt: file.title }) %>
+                      { :'data-fullsrc' => view_dmsf_file_url(file), alt: file.title }) %>
                 <% end %>
               </div>
           <% end %>

--- a/lib/redmine_dmsf/macros.rb
+++ b/lib/redmine_dmsf/macros.rb
@@ -47,7 +47,7 @@ module RedmineDmsf
         title.gsub! /\A"|"\z/, '' # Remove apostrophes
         title.gsub! /\A'|'\z/, ''
         title = file.title if title.empty?
-        url = view_dmsf_file_path(id: file.id, download: args[2])
+        url = view_dmsf_file_url(id: file.id, download: args[2])
         link_to h(title), url, target: '_blank', title: h(revision.tooltip),
           'data-downloadurl' => "#{file.last_revision.detect_content_type}:#{h(file.name)}:#{url}"
       end
@@ -169,7 +169,7 @@ module RedmineDmsf
           raise l(:notice_not_authorized)
         end
         raise 'Not supported image format' unless file.image?
-        url = view_dmsf_file_path(file)
+        url = view_dmsf_file_url(file)
         if size&.include?('%')
           image_tag url, alt: file.title, width: size, height: size
         elsif height
@@ -200,7 +200,7 @@ module RedmineDmsf
           raise l(:notice_not_authorized)
         end
         raise 'Not supported video format' unless file.video?
-        url = view_dmsf_file_path(file)
+        url = view_dmsf_file_url(file)
         if size&.include?('%')
           video_tag url, controls: true, alt: file.title, width: size, height: size
         elsif height
@@ -230,7 +230,7 @@ module RedmineDmsf
           raise l(:notice_not_authorized)
         end
         raise 'Not supported image format' unless file.image?
-        url = view_dmsf_file_path(file)
+        url = view_dmsf_file_url(file)
         if size
           img = image_tag(url, alt: file.title, size: size)
         elsif height

--- a/test/unit/lib/redmine_dmsf/dmsf_macros_test.rb
+++ b/test/unit/lib/redmine_dmsf/dmsf_macros_test.rb
@@ -220,46 +220,46 @@ class DmsfMacrosTest < RedmineDmsf::Test::HelperTest
   # {{dmsf_image(file_id)}}
   def test_macro_dmsf_image
     text = textilizable("{{dmsf_image(#{@file7.id})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, size: nil)
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, size: nil)
     assert_equal "<p>#{link}</p>", text
   end
 
   def test_macro_dmsf_image_size
     size = '50%'
     text = textilizable("{{dmsf_image(#{@file7.id}, size=#{size})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, width: size, height: size)
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, width: size, height: size)
     assert_equal "<p>#{link}</p>", text
     size = '300'
     text = textilizable("{{dmsf_image(#{@file7.id}, size=#{size})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, width: size, height: size)
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, width: size, height: size)
     # TODO: arguments src and with and height are swapped
     #assert_equal "<p>#{link}</p>", text
     size = '640x480'
     text = textilizable("{{dmsf_image(#{@file7.id}, size=#{size})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, width: '640', height: '480')
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, width: '640', height: '480')
     # TODO: arguments src and with and height are swapped
     #assert_equal "<p>#{link}</p>", text
     height = '480'
     text = textilizable("{{dmsf_image(#{@file7.id}, height=#{height})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, width: 'auto', height: height)
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, width: 'auto', height: height)
     assert_equal "<p>#{link}</p>", text
     width = '480'
     text = textilizable("{{dmsf_image(#{@file7.id}, width=#{height})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, width: width, height: 'auto')
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, width: width, height: 'auto')
     assert_equal "<p>#{link}</p>", text
   end
 
   def test_macro_dmsf_image_no_permissions
     @manager_role.remove_permission! :view_dmsf_files
     text = textilizable("{{dmsf_image(#{@file7.id})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, size: nil)
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, size: nil)
     assert_not_equal "<p>#{link}</p>", text
   end
 
   def test_macro_dmsf_image_dmsf_off
     @project1.disable_module! :dmsf
     text = textilizable("{{dmsf_image(#{@file7.id})}}")
-    link = image_tag(view_dmsf_file_path(@file7), alt: @file7.title, size: nil)
+    link = image_tag(view_dmsf_file_url(@file7), alt: @file7.title, size: nil)
     assert_not_equal "<p>#{link}</p>", text
   end
 
@@ -271,44 +271,44 @@ class DmsfMacrosTest < RedmineDmsf::Test::HelperTest
   # {{dmsf_video(file_id)}}
   def test_macro_dmsf_video
     text = textilizable("{{dmsf_video(#{@file6.id})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title)
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title)
     assert_equal "<p>#{link}</p>", text
   end
 
   def test_macro_dmsf_image_size
     size = '50%'
     text = textilizable("{{dmsf_video(#{@file6.id}, size=#{size})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title, width: size, height: size)
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title, width: size, height: size)
     assert_equal "<p>#{link}</p>", text
     size = '300'
     text = textilizable("{{dmsf_video(#{@file6.id}, size=#{size})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title, width: size, height: size)
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title, width: size, height: size)
     assert_equal "<p>#{link}</p>", text
     size = '640x480'
     text = textilizable("{{dmsf_video(#{@file6.id}, size=#{size})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title, width: '640', height: '480')
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title, width: '640', height: '480')
     assert_equal "<p>#{link}</p>", text
     height = '480'
     text = textilizable("{{dmsf_video(#{@file6.id}, height=#{height})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title, width: 'auto', height: height)
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title, width: 'auto', height: height)
     assert_equal "<p>#{link}</p>", text
     width = '480'
     text = textilizable("{{dmsf_video(#{@file6.id}, width=#{height})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title, width: width, height: 'auto')
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title, width: width, height: 'auto')
     assert_equal "<p>#{link}</p>", text
   end
 
   def test_macro_dmsf_image_no_permissions
     @manager_role.remove_permission! :view_dmsf_files
     text = textilizable("{{dmsf_video(#{@file6.id})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title)
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title)
     assert_not_equal "<p>#{link}</p>", text
   end
 
   def test_macro_dmsf_image_dmsf_off
      @project1.disable_module! :dmsf
     text = textilizable("{{dmsf_video(#{@file6.id})}}")
-    link = video_tag(view_dmsf_file_path(@file6), controls: true, alt: @file6.title)
+    link = video_tag(view_dmsf_file_url(@file6), controls: true, alt: @file6.title)
     assert_not_equal "<p>#{link}</p>", text
   end
 
@@ -320,7 +320,7 @@ class DmsfMacrosTest < RedmineDmsf::Test::HelperTest
   # {{dmsftn(file_id)}}
   def test_macro_dmsftn
     text = textilizable("{{dmsftn(#{@file7.id})}}")
-    url = view_dmsf_file_path(@file7)
+    url = view_dmsf_file_url(@file7)
     img = image_tag(url, alt: @file7.title, width: 'auto', height: 200)
     link = link_to(img, url, target: '_blank', title: h(@file7.last_revision.try(:tooltip)),
                    'data-downloadurl' => "#{@file7.last_revision.detect_content_type}:#{h(@file7.name)}:#{url}")
@@ -328,7 +328,7 @@ class DmsfMacrosTest < RedmineDmsf::Test::HelperTest
   end
 
   def test_macro_dmsftn
-    url = view_dmsf_file_path(@file7)
+    url = view_dmsf_file_url(@file7)
     size = '300'
     text = textilizable("{{dmsftn(#{@file7.id}, size=#{size})}}")
     img = image_tag(url, alt: @file7.title, size: size)
@@ -359,7 +359,7 @@ class DmsfMacrosTest < RedmineDmsf::Test::HelperTest
   def test_macro_dmsftn_no_permissions
     @manager_role.remove_permission! :view_dmsf_files
     text = textilizable("{{dmsftn(#{@file7.id})}}")
-    url = view_dmsf_file_path(@file7)
+    url = view_dmsf_file_url(@file7)
     img = image_tag(url, alt: @file7.title, width: 'auto', height: 200)
     link = link_to(img, url, target: '_blank', title: h(@file7.last_revision.try(:tooltip)),
                    'data-downloadurl' => "#{@file7.last_revision.detect_content_type}:#{h(@file7.name)}:#{url}")
@@ -369,7 +369,7 @@ class DmsfMacrosTest < RedmineDmsf::Test::HelperTest
   def test_macro_dmsftn_dmsf_off
     @project1.disable_module! :dmsf
     text = textilizable("{{dmsftn(#{@file7.id})}}")
-    url = view_dmsf_file_path(@file7)
+    url = view_dmsf_file_url(@file7)
     img = image_tag(url, alt: @file7.title, width: 'auto', height: 200)
     link = link_to(img, url, target: '_blank', title: h(@file7.last_revision.try(:tooltip)),
                    'data-downloadurl' => "#{@file7.last_revision.detect_content_type}:#{h(@file7.name)}:#{url}")


### PR DESCRIPTION
This change fixes email notification rendering of DMSF file links as referenced in Issue #1371 -- replacing all instances of `view_dmsf_file_path` with `view_dmsf_file_url`

The resulting email showed the correctly rendered URL directly to the document:

`Testing DMSF link to this project: [$file_name](https://$URL/dmsf/files/96/view)