### PR TITLE
Update fa.yml

### DIFF
--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -327,7 +327,8 @@ fa:
 
   locked_documents: اسناد قفل شده
   open_approvals: تاییدهای باز
-
+  watched_documents: مستندات تحت نظارت
+  
   error_maximum_upload_filecount: "بیش از %{filecount} فایل نمی‌تواند بارگذاری شود."
 
   label_public_urls: نشانی‌های عمومی تا این تاریخ معتبرند


### PR DESCRIPTION
Lables that shown on 'add block' dropdown  in 'my page' was generated from blocks partial file names. Because of that, phrase 'Watched documents' does not support I18n and always shown as 'Watched documents'.

add `watched_documents` to support I18n on 'my page' add block dropdown.