### PR TITLE
Adds formatting helper to all editors

### DIFF
--- a/lib/redmine_dmsf/patches/formatting_helper_patch.rb
+++ b/lib/redmine_dmsf/patches/formatting_helper_patch.rb
@@ -59,3 +59,5 @@ end
 
 # Apply the patch
 Redmine::WikiFormatting::Textile::Helper.prepend RedmineDmsf::Patches::FormattingHelperPatch
+Redmine::WikiFormatting::Markdown::Helper.prepend RedmineDmsf::Patches::FormattingHelperPatch
+Redmine::WikiFormatting::CommonMark::Helper.prepend RedmineDmsf::Patches::FormattingHelperPatch


### PR DESCRIPTION
The formatting_helper_patch is included in textile wiki formatting helper but not in markdown and commonmark formatting helper. Therefore, the dms toobar icon is missing with these editors.

This patch adds the formatting_helper_patch to all missing editors.