### PR TITLE
fix .zero? error in id_attribute check

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -422,7 +422,7 @@ class DmsfFile < ApplicationRecord
           dmsf_attrs = filename.scan(%r{^([^/]+/[^_]+)_(\d+)_(.*)$})
           id_attribute = 0
           id_attribute = dmsf_attrs[0][1] if dmsf_attrs.length.positive?
-          next if dmsf_attrs.length.zero? || id_attribute.zero?
+          next if dmsf_attrs.length.zero? || id_attribute.to_i.zero?
           next unless results.select { |f| f.id.to_s == id_attribute }.empty?
 
           dmsf_file = DmsfFile.visible.where(limit_options).find_by(id: id_attribute)


### PR DESCRIPTION
I got this error when searching: 

    [6adb7d18-ed52-428b-ad9c-8c602234****] NoMethodError (undefined method `zero?' for "25496":String

              next if dmsf_attrs.length.zero? || id_attribute.zero?
                                                         ^^^^^^):
    [6adb7d18-ed52-428b-ad9c-8c602234****]
    [6adb7d18-ed52-428b-ad9c-8c602234****] plugins/redmine_dmsf/app/models/dmsf_file.rb:425:in `block in search'

so I added ".to_i" before the .zero? to fix the error.