### PR TITLE
Bug fixing/wrong number of arguments in dmsf links new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /redmine_dmsf.iml
 Gemfile.lock
 .history
+tmp/

--- a/app/helpers/dmsf_links_helper.rb
+++ b/app/helpers/dmsf_links_helper.rb
@@ -35,7 +35,7 @@ module DmsfLinksHelper
     str&.match?(/\A\d+\Z/)
   end
 
-  def files_for_select(project_id, folder_id)
+  def files_for_select(project_id, folder_id = nil)
     files = []
     if DmsfLinksHelper.number?(folder_id)
       folder = DmsfFolder.find_by(id: folder_id)

--- a/app/views/dmsf_links/_form.html.erb
+++ b/app/views/dmsf_links/_form.html.erb
@@ -110,8 +110,8 @@
     </div>
   </div>
 <% end %>
-
 <%= late_javascript_tag do %>
+$(document).ready(function(){
   <%# Select2 extension, TODO: in case of a modal window, select2 makes problems %>
   <% unless modal || @fast_links %>
     $('#dmsf_link_target_project_id').select2();
@@ -148,4 +148,5 @@
       labelUrl.append('<span class="required"> *</span>');
     }
   });
+});
 <% end %>

--- a/test/helpers/dmsf_links_helper_test.rb
+++ b/test/helpers/dmsf_links_helper_test.rb
@@ -31,4 +31,11 @@ class DmsfLinksHelperTest < RedmineDmsf::Test::HelperTest
     assert_not DmsfLinksHelper.number?('123a')
     assert_not DmsfLinksHelper.number?(nil)
   end
+
+  def test_default_folder_id_in_files_for_select
+    project = Project.find(1)
+    assert_nothing_raised do
+      files_for_select(project.id)
+    end
+  end
 end


### PR DESCRIPTION
Hi @picman,

I stumpled upon two bugs with the dmsf link functionality. The bugs are located in version 3.1.0 and probably also in lower versions:

1) Wrong number of arguments in DmsfLinksHelper#files_for_select

```shell
ActionView::Template::Error (wrong number of arguments (given 1, expected 2)):
    86:       <% if @type == 'link_from' %>
    87:         <p>
    88:           <%= label_tag 'dmsf_link[target_file_id]', l(:field_target_file) %>
    89:           <% files = files_for_select(@dmsf_link.target_project.id) %>
    90:           <%= select_tag 'dmsf_link[target_file_id]', options_for_select(DmsfFolder.file_list(files)), required: modal %>
    91:         </p>
    92:       <% end %>
  
plugins/redmine_dmsf/app/helpers/dmsf_links_helper.rb:38:in `files_for_select'
plugins/redmine_dmsf/app/views/dmsf_links/_form.html.erb:89
```

You can reproduce the error when you try to add a dmsf link in either an issue or in the dmsf project module itself. 

2) Uncaught TypeError: $(...).select2 is not a function

The second error occurs as soon as the view `dmsf_links/_form.html.erb` is loaded.  The consequence is that the user won`t be able to create an external link. Though this error does not affect the link creation on issues.

Both errors will be fixed with this PR.  

I am happy to help you!

@liaham