### PR TITLE
Removes main menu from workflows controller

### DIFF
--- a/app/controllers/dmsf_workflows_controller.rb
+++ b/app/controllers/dmsf_workflows_controller.rb
@@ -22,6 +22,7 @@
 class DmsfWorkflowsController < ApplicationController
   model_object DmsfWorkflow
   menu_item :dmsf_approvalworkflows
+  self.main_menu = false
 
   before_action :find_model_object, except: %i[create new index assign assignment]
   before_action :find_project


### PR DESCRIPTION
Hi,

This is a small improvement for more layout consistency.

Usually the main menu is not displayed in admin area. Therefore, it will be removed in workflow controller with this commit.

It does not break tests and has no conflict with workflows on project level.

Best Regards,
@liaham 