### PR TITLE
Adds an extra check in DmsfQuery#dmsf_node

### DIFF
--- a/app/models/dmsf_query.rb
+++ b/app/models/dmsf_query.rb
@@ -232,6 +232,8 @@ class DmsfQuery < Query
             !dmsf_link.dmsf_folder.visible? || !DmsfFolder.permissions?(dmsf_link.dmsf_folder, allow_system: false)
           elsif dmsf_link.project
             !dmsf_link.project.dmsf_available?
+          else
+            !dmsf_link.project&.dmsf_available?
           end
         else
           false

--- a/app/models/dmsf_query.rb
+++ b/app/models/dmsf_query.rb
@@ -230,7 +230,7 @@ class DmsfQuery < Query
           dmsf_link = DmsfLink.find_by(id: item.id)
           if dmsf_link.dmsf_folder
             !dmsf_link.dmsf_folder.visible? || !DmsfFolder.permissions?(dmsf_link.dmsf_folder, allow_system: false)
-          else
+          elsif dmsf_link.project
             !dmsf_link.project.dmsf_available?
           end
         else


### PR DESCRIPTION
This change stablizes the query with DmsfLink objects since they could have stored a project_id of -1 causing a nil error.

This may happen when the linking of a dms document with an issue was not successful or aborted as observed with https://github.com/danmunn/redmine_dmsf/pull/1466.