### PR TITLE
Adds further validations

### DIFF
--- a/app/models/dmsf_file.rb
+++ b/app/models/dmsf_file.rb
@@ -42,6 +42,7 @@ class DmsfFile < ApplicationRecord
   scope :deleted, -> { where(deleted: STATUS_DELETED) }
 
   validates :name, dmsf_file_name: true
+  validates :name, length: { maximum: 255 }
   validates :name,
             uniqueness: {
               scope: %i[dmsf_folder_id project_id deleted],

--- a/app/models/dmsf_file_revision.rb
+++ b/app/models/dmsf_file_revision.rb
@@ -90,8 +90,11 @@ class DmsfFileRevision < ApplicationRecord
   )
 
   validates :title, presence: true
+  validates :title, length: { maximum: 255 }
   validates :major_version, presence: true
   validates :name, dmsf_file_name: true
+  validates :name, length: { maximum: 255 }
+  validates :disk_filename, length: { maximum: 255 }
   validates :description, length: { maximum: 1.kilobyte }
   validates :size, dmsf_max_file_size: true
 

--- a/test/unit/dmsf_file_revision_test.rb
+++ b/test/unit/dmsf_file_revision_test.rb
@@ -37,21 +37,28 @@ class DmsfFileRevisionTest < RedmineDmsf::Test::UnitTest
   end
 
   def test_file_title_length_validation
-    file = DmsfFileRevision.new(title: Array.new(256).map { 'a' }.join)
+    file = DmsfFileRevision.new(title: Array.new(256).map { 'a' }.join,
+                                name: 'Test Revision',
+                                major_version: 1)
     assert file.invalid?
     assert_equal ['Title is too long (maximum is 255 characters)'], file.errors.full_messages
   end
 
   def test_file_name_length_validation
-    file = DmsfFileRevision.new(name: Array.new(256).map { 'a' }.join)
+    file = DmsfFileRevision.new(name: Array.new(256).map { 'a' }.join,
+                                title: 'Test Revision',
+                                major_version: 1)
     assert file.invalid?
     assert_equal ['Name is too long (maximum is 255 characters)'], file.errors.full_messages
   end
 
   def test_file_disk_filename_length_validation
-    file = DmsfFileRevision.new(disk_filename: Array.new(256).map { 'a' }.join)
+    file = DmsfFileRevision.new(disk_filename: Array.new(256).map { 'a' }.join,
+                                title: 'Test Revision',
+                                name: 'Test Revision',
+                                major_version: 1)
     assert file.invalid?
-    assert_equal ['Disk Filename is too long (maximum is 255 characters)'], file.errors.full_messages
+    assert_equal ['Disk filename is too long (maximum is 255 characters)'], file.errors.full_messages
   end
 
   def test_delete_restore

--- a/test/unit/dmsf_file_revision_test.rb
+++ b/test/unit/dmsf_file_revision_test.rb
@@ -36,6 +36,24 @@ class DmsfFileRevisionTest < RedmineDmsf::Test::UnitTest
     @wf1 = DmsfWorkflow.find 1
   end
 
+  def test_file_title_length_validation
+    file = DmsfFileRevision.new(title: Array.new(256).map { 'a' }.join)
+    assert file.invalid?
+    assert_equal ['Title is too long (maximum is 255 characters)'], file.errors.full_messages
+  end
+
+  def test_file_name_length_validation
+    file = DmsfFileRevision.new(name: Array.new(256).map { 'a' }.join)
+    assert file.invalid?
+    assert_equal ['Name is too long (maximum is 255 characters)'], file.errors.full_messages
+  end
+
+  def test_file_disk_filename_length_validation
+    file = DmsfFileRevision.new(disk_filename: Array.new(256).map { 'a' }.join)
+    assert file.invalid?
+    assert_equal ['Disk Filename is too long (maximum is 255 characters)'], file.errors.full_messages
+  end
+
   def test_delete_restore
     @revision5.delete commit: false
     assert @revision5.deleted?, "File revision #{@revision5.name} hasn't been deleted"

--- a/test/unit/dmsf_file_test.rb
+++ b/test/unit/dmsf_file_test.rb
@@ -32,6 +32,12 @@ class DmsfFileTest < RedmineDmsf::Test::UnitTest
     @wf2 = DmsfWorkflow.find 2
   end
 
+  def test_file_name_length_validation
+    file = DmsfFile.new(name: Array.new(256).map { 'a' }.join)
+    assert file.invalid?
+    assert_equal ['Name is too long (maximum is 255 characters)'], file.errors.full_messages
+  end
+
   def test_project_file_count_differs_from_project_visibility_count
     assert_not_same @project1.dmsf_files.all.size, @project1.dmsf_files.visible.all.size
   end


### PR DESCRIPTION
The models DmsfFile and DmsfFileRevision will get validations on database restricted strings such that title, name, disk_filename.