### PR TITLE
Adds missing safe_attribute for dmsf_not_inheritable

### DIFF
--- a/lib/redmine_dmsf.rb
+++ b/lib/redmine_dmsf.rb
@@ -40,6 +40,7 @@ require "#{File.dirname(__FILE__)}/redmine_dmsf/patches/pdf_patch"
 require "#{File.dirname(__FILE__)}/redmine_dmsf/patches/access_control_patch"
 require "#{File.dirname(__FILE__)}/redmine_dmsf/patches/search_patch"
 require "#{File.dirname(__FILE__)}/redmine_dmsf/patches/search_controller_patch"
+require "#{File.dirname(__FILE__)}/redmine_dmsf/patches/custom_field_patch"
 
 # A workaround for obsolete 'alias_method' usage in RedmineUp's plugins
 if RedmineDmsf::Plugin.an_obsolete_plugin_present?

--- a/lib/redmine_dmsf/patches/custom_field_patch.rb
+++ b/lib/redmine_dmsf/patches/custom_field_patch.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Redmine plugin for Document Management System "Features"
+#
+# Karel Pičman <karel.picman@kontron.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+module RedmineDmsf
+  module Patches
+    # CustomField patch
+    module CustomFieldPatch
+      def self.included(base)
+        base.class_eval do
+          safe_attributes :dmsf_not_inheritable
+        end
+      end
+    end
+  end
+end
+
+# Apply patch
+if Redmine::Plugin.installed?('easy_extensions')
+  RedmineExtensions::PatchManager.register_model_patch 'CustomField', 'RedmineDmsf::Patches::CustomFieldPatch'
+else
+  CustomField.include RedmineDmsf::Patches::CustomFieldPatch
+end

--- a/test/unit/custom_field_path_test.rb
+++ b/test/unit/custom_field_path_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Redmine plugin for Document Management System "Features"
+#
+# Karel Pičman <karel.picman@kontron.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+require File.expand_path('../../test_helper', __FILE__)
+
+# CustomField patch test
+class CustomFieldTest < RedmineDmsf::Test::UnitTest
+  def test_should_have_dmsf_not_inheritable_listed_as_safe_attribute
+    assert CustomField.new.safe_attribute_names.include?('dmsf_not_inheritable')
+  end
+end


### PR DESCRIPTION
Dmsf custom field settings are extended with a further attribute called dmsf_not_inheritable. This attribute is added to Redmine CustomField.safe_attributes.

Hence dmsf_not_inheritable will be saved now!