### PR TITLE
Fixing NoMethodError in DmsfFileRevisionFormat

### DIFF
--- a/lib/redmine_dmsf/field_formats/dmsf_file_revision_format.rb
+++ b/lib/redmine_dmsf/field_formats/dmsf_file_revision_format.rb
@@ -30,7 +30,7 @@ module RedmineDmsf
 
       def edit_tag(view, tag_id, tag_name, custom_value, options = {})
         member = Member.find_by(user_id: User.current.id, project_id: custom_value.customized.project.id)
-        if member.dmsf_fast_links?
+        if member&.dmsf_fast_links?
           view.text_field_tag(tag_name, custom_value.value, options.merge(id: tag_id))
         else
           select_edit_tag(view, tag_id, tag_name, custom_value, options)

--- a/test/unit/custom_field_dmsf_file_format_test.rb
+++ b/test/unit/custom_field_dmsf_file_format_test.rb
@@ -37,4 +37,20 @@ class CustomFieldDmsfFileFormatTest < RedmineDmsf::Test::UnitTest
     end
     assert_equal n, @field.possible_values_options(@issue).size
   end
+
+  def test_edit_tag_when_member_not_found
+    User.current = User.generate!
+    view = ActionView::Base.new(ActionController::Base.view_paths, {}, ActionController::Base.new)
+    view.extend(ApplicationHelper)
+
+    begin
+      @field.format.edit_tag(view,
+                             "issue_custom_field_values_#{@field.id}",
+                             "issue[custom_field_values][#{@field.id}]",
+                             CustomValue.create!(custom_field: @field, customized: @issue))
+      assert true
+    rescue NoMethodError => e
+      flunk "Test failure: #{e.message}"
+    end
+  end
 end


### PR DESCRIPTION
When an issue with a custom field format DmsfFileRevision should be created by a non-member an exception would be raised without this commit.

A non-member could always be an admin or in fact a non-member in case of a public project.