### PR TITLE
Add redmine_products to obsolete plugin list

### DIFF
--- a/lib/redmine_dmsf/plugin.rb
+++ b/lib/redmine_dmsf/plugin.rb
@@ -29,9 +29,10 @@ module RedmineDmsf
 
     # Return true if a plugin that overrides Redmine::Notifiable and use the deprecated method alias_method_chain is
     # present.
-    # It is related especially to plugins made by AplhaNode and RedmineUP.
+    # It is related especially to plugins made by AlphaNode and RedmineUP.
     def self.an_obsolete_plugin_present?
-      plugins = %w[easyproject/easy_plugins/easy_money redmine_questions redmine_db redmine_passwords redmine_resources]
+      plugins = %w[easyproject/easy_plugins/easy_money redmine_questions redmine_db redmine_passwords redmine_resources
+                   redmine_products]
       plugins.each do |plugin|
         return true if Plugin.present?(plugin)
       end


### PR DESCRIPTION
With redmine_products (and its dependency redmine_contacts) installed, SystemStackError occurs when going to administrative settings:

	I, [2024-07-18T20:22:39.380403 #1]  INFO -- : Started GET "/settings" for 172.17.0.1 at 2024-07-18 20:22:39 +0000
	I, [2024-07-18T20:22:39.381060 #1]  INFO -- : Processing by SettingsController#index as HTML
	I, [2024-07-18T20:22:39.384106 #1]  INFO -- :   Current user: admin (id=1)
	I, [2024-07-18T20:22:39.396807 #1]  INFO -- : Completed 500 Internal Server Error in 16ms (ActiveRecord: 0.4ms | Allocations: 11130)
	F, [2024-07-18T20:22:39.532960 #1] FATAL -- :
	SystemStackError (stack level too deep):

	plugins/redmine_products/lib/redmine_products/patches/notifiable_patch.rb:35:in `all_with_products'
	plugins/redmine_dmsf/lib/redmine_dmsf/patches/notifiable_patch.rb:37:in `all'
	...
	plugins/redmine_products/lib/redmine_products/patches/notifiable_patch.rb:35:in `all_with_products'
	plugins/redmine_dmsf/lib/redmine_dmsf/patches/notifiable_patch.rb:37:in `all'
	app/controllers/settings_controller.rb:37:in `edit'
	app/controllers/settings_controller.rb:32:in `index'
	lib/redmine/sudo_mode.rb:61:in `sudo_mode'

Fixes: 648bed260cdf ("Adminstration-settings cannot open after dmsf installed #1506")
Fixes danmunn/redmine_dmsf#1537
Related to danmunn/redmine_dmsf#1506