### PR TITLE
Some controller hooks won't get loaded

### DIFF
--- a/lib/redmine_dmsf.rb
+++ b/lib/redmine_dmsf.rb
@@ -72,7 +72,9 @@ require "#{File.dirname(__FILE__)}/redmine_dmsf/errors/dmsf_zip_max_files_error"
 
 # Hooks
 def require_hooks
+  require "#{File.dirname(__FILE__)}/redmine_dmsf/hooks/controllers/account_controller_hooks"
   require "#{File.dirname(__FILE__)}/redmine_dmsf/hooks/controllers/issues_controller_hooks"
+  require "#{File.dirname(__FILE__)}/redmine_dmsf/hooks/controllers/search_controller_hooks"
   require "#{File.dirname(__FILE__)}/redmine_dmsf/hooks/views/view_projects_form_hook"
   require "#{File.dirname(__FILE__)}/redmine_dmsf/hooks/views/base_view_hooks"
   require "#{File.dirname(__FILE__)}/redmine_dmsf/hooks/views/custom_field_view_hooks"


### PR DESCRIPTION
There are several hooks in lib/redmine_dmsf.rb listed to get loaded but two of them in lib/redmine_dmsf/hooks/controllers are missing:

- account_controller_hooks
- search_controller_hooks

Therefore, webdav digest won't be created and the search feature (not Redmine default) won't be available.