### PR TITLE
Changes token action name for WebDAV digest

### DIFF
--- a/app/views/hooks/redmine_dmsf/_view_my_account.html.erb
+++ b/app/views/hooks/redmine_dmsf/_view_my_account.html.erb
@@ -31,7 +31,7 @@
 <% if Setting.plugin_redmine_dmsf['dmsf_webdav_authentication'] == 'Digest' %>
   <p>
     <label for='webdav_digest_reset'><%= l(:label_dmsf_webdav_digest) %></label>
-    <% token = Token.find_by(user_id: @user.id, action: 'dmsf-webdav-digest') %>
+    <% token = Token.find_by(user_id: @user.id, action: 'dmsf_webdav_digest') %>
     <% if token %>
       <%= l(:label_dmsf_webdav_digest_created_on, distance_of_time_in_words(Time.now, token.created_on)) %>
     <% else %>


### PR DESCRIPTION
The partial views/hooks/redmine_dmsf/_view_my_account.html.erb uses a finder method where the action name still uses kebab case but since migration 20240829093801_rename_dmsf_digest_token.rb it is required to use snake case.

That is, dmsf-webdav-digest needs to be renamed to dmsf_webdav_digest to find the token of the current user.