### PR TITLE
Adds further text to reset button of webdav digest

### DIFF
--- a/app/views/hooks/redmine_dmsf/_view_my_account.html.erb
+++ b/app/views/hooks/redmine_dmsf/_view_my_account.html.erb
@@ -31,12 +31,13 @@
 <% if Setting.plugin_redmine_dmsf['dmsf_webdav_authentication'] == 'Digest' %>
   <p>
     <label for='webdav_digest_reset'><%= l(:label_dmsf_webdav_digest) %></label>
-    <% token = Token.find_by(user_id: @user.id, action: 'dmsf-webdav-digest') %>
+    <% token = Token.find_by(user_id: @user.id, action: 'dmsf_webdav_digest') %>
     <% if token %>
       <%= l(:label_dmsf_webdav_digest_created_on, distance_of_time_in_words(Time.now, token.created_on)) %>
+      (<%= link_to l(:button_reset), dmsf_digest_path, remote: true, id: 'webdav_digest_reset' %>)
     <% else %>
       <%= l(:label_missing_dmsf_webdav_digest) %>
+      (<%= link_to l(:button_add), dmsf_digest_path, remote: true, id: 'webdav_digest_reset' %>)
     <% end %>
-    (<%= link_to l(:button_reset), dmsf_digest_path, remote: true, id: 'webdav_digest_reset' %>)
   </p>
 <% end %>


### PR DESCRIPTION
When a user has 2FA enabled the WebDAV digest won't be created on sign in. The reason is in RedmineDmsf::Hooks::Controllers:: AccountControllerHooks#controller_account_success_authentication_after where the digest will be created only if the controller parameter ':password' is present. This works for a user authentication with login name and password only. A user with 2fa enabled runs differently through the authentication process and crosses the hook not before the 2fa token was checked. Hence, there won't be a password parameter anymore.

Instead of manipulating controller params to provide the password only the button text for reseting the digest will be changed if the user has (2FA but) no digest yet. This would make it more explicit that the token is not expected to exist and can be created if missing.