### PR TITLE
Fixes Column 'dmsf_mail_notification' cannot be null

### DIFF
--- a/app/controllers/dmsf_state_controller.rb
+++ b/app/controllers/dmsf_state_controller.rb
@@ -28,7 +28,9 @@ class DmsfStateController < ApplicationController
   def user_pref_save
     member = @project.members.find_by(user_id: User.current.id)
     if member
-      member.dmsf_mail_notification = params[:email_notify]
+      if Setting.notified_events.include?('dmsf_legacy_notifications')
+        member.dmsf_mail_notification = params[:email_notify]
+      end
       member.dmsf_title_format = params[:title_format]
       member.dmsf_fast_links = params[:fast_links].present?
       if format_valid?(member.dmsf_title_format) && member.save


### PR DESCRIPTION
The partial app/views/dmsf_state/_user_pref.html.erb uses a condition to include the email_notify setting only if the corresponding notified_event is enabled. The database field email_notify, however, does not accept a null value. But this is what occurs when the notified event is disabled.

This patch changes the DmsfStateController to assign params[:email_notify] only if the notified_event for dmsf_legacy_notifications is enabled.