### PR TITLE
Emails are not sent to the author if no_self_notified

### DIFF
--- a/app/models/dmsf_mailer.rb
+++ b/app/models/dmsf_mailer.rb
@@ -158,9 +158,19 @@ class DmsfMailer < Mailer
     @notice = notice
     @author = revision.dmsf_workflow_assigned_by_user
     @author ||= User.anonymous
-    mail to: user,
-         subject:
-           "[#{@project.name} - #{l(:field_label_dmsf_workflow)}] #{@workflow.name} #{l(subject_id)} #{step_name}"
+    skip_no_self_notified = false
+    begin
+      # We need to switch off no_self_notified temporarily otherwise the email won't be sent
+      if (@author == user) && @author.pref.no_self_notified
+        @author.pref.no_self_notified = false
+        skip_no_self_notified = true
+      end
+      mail to: user,
+          subject:
+            "[#{@project.name} - #{l(:field_label_dmsf_workflow)}] #{@workflow.name} #{l(subject_id)} #{step_name}"
+    ensure
+      @author.pref.no_self_notified = true if skip_no_self_notified
+    end
   end
 
   # force_notification = true => approval workflow's notifications

--- a/app/models/dmsf_mailer.rb
+++ b/app/models/dmsf_mailer.rb
@@ -166,7 +166,7 @@ class DmsfMailer < Mailer
         skip_no_self_notified = true
       end
       mail to: user,
-          subject:
+           subject:
             "[#{@project.name} - #{l(:field_label_dmsf_workflow)}] #{@workflow.name} #{l(subject_id)} #{step_name}"
     ensure
       @author.pref.no_self_notified = true if skip_no_self_notified


### PR DESCRIPTION
Hi there, I dug long time to know how approval workflow working, I realized that when approved happen, in some cases author would be same as user that mail would send, which means that if user ignore the mail notification which sent by himself, he would not receive the notification that approve initialize by himself. That will be not making sense especially when I change the document and need others review then I would like to receive that others review done case.

Overall, I copy the logic from send documents to bypass the no_self_notified temporally to make it happen. Please kindly review this patch and I am sorry to push it to master as devel branch sadly just support Redmine 6.0.x. I hope this mechanism can be real and I can use it in real. Thank you.