### PR TITLE
remove unloadable from notifiable patch

### DIFF
--- a/patches/notifiable_ru_patch.rb
+++ b/patches/notifiable_ru_patch.rb
@@ -26,7 +26,6 @@ module RedmineDmsf
       def self.included(base)
         base.extend ClassMethods
         base.class_eval do
-          unloadable
           class << self
             alias_method :all_without_resources_dmsf, :all
             alias_method :all, :all_with_resources_dmsf


### PR DESCRIPTION
"unloadable" does not work with Redmine 6.